### PR TITLE
fix: remove default value from docker-stack.yml

### DIFF
--- a/docker-stack.yml
+++ b/docker-stack.yml
@@ -15,7 +15,7 @@ version: "3.8"
 
 services:
   mobile:
-    image: ${MOBILE_IMAGE:-ghcr.io/iu-alumni/iu-alumni-mobile:latest}
+    image: ${MOBILE_IMAGE}
     networks:
       iu_alumni_network:
         aliases:


### PR DESCRIPTION
- Remove `:-default` fallback from `MOBILE_IMAGE`; value must be set explicitly via the shared `.env`