### PR TITLE
fix: use dart:js_interop_unsafe globalContext to read runtime API URL

### DIFF
--- a/lib/data/config/api_config.dart
+++ b/lib/data/config/api_config.dart
@@ -1,2 +1,2 @@
 export 'api_config_stub.dart'
-    if (dart.library.html) 'api_config_web.dart';
+    if (dart.library.js_interop) 'api_config_web.dart';

--- a/lib/data/config/api_config_web.dart
+++ b/lib/data/config/api_config_web.dart
@@ -1,15 +1,16 @@
 import 'dart:js_interop';
+import 'dart:js_interop_unsafe';
 
 /// Web implementation: reads the API base URL injected at runtime by the
 /// nginx entrypoint into window.apiBaseUrl (see web/index.html placeholder).
 /// Falls back to the compile-time --dart-define value if not set.
-@JS('apiBaseUrl')
-external JSString? get _jsApiBaseUrl;
-
 String getApiBaseUrl() {
   try {
-    final url = _jsApiBaseUrl?.toDart;
-    if (url != null && url.startsWith('http')) return url;
+    final jsValue = globalContext['apiBaseUrl'];
+    if (jsValue != null && jsValue.typeofEquals('string')) {
+      final url = (jsValue as JSString).toDart;
+      if (url.startsWith('http')) return url;
+    }
   } catch (_) {}
   return const String.fromEnvironment('API_BASE_URL');
 }


### PR DESCRIPTION
## Problem

The `index.html` correctly has `window.apiBaseUrl` set at container start, but the Dart code was not reading it — app still resolved API requests relative to mobile host.

## Root cause

1. **Wrong conditional export condition**: `dart.library.html` may not evaluate to `true` on Flutter web in Dart 3.8+, causing the stub (`String.fromEnvironment`) to be used instead of the web implementation.
2. **Unreliable `@JS` external declaration**: Top-level `@JS("apiBaseUrl") external JSString?` from `dart:js_interop` does not reliably access window globals in all Flutter web build configurations.

## Fix

- `api_config.dart`: condition changed from `dart.library.html` to `dart.library.js_interop`
- `api_config_web.dart`: replaced `@JS` external declaration with `dart:js_interop_unsafe` `globalContext["apiBaseUrl"]` — the officially recommended dynamic property access in Dart 3