### PR TITLE
fix: add robots.txt to disallow crawlers

### DIFF
--- a/web/robots.txt
+++ b/web/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /


### PR DESCRIPTION
## Summary

Adds a `robots.txt` file to the Flutter web app to disallow all crawlers.

The IU Alumni platform is a private app and should not be indexed by search engines. Bots (including OpenAI SearchBot) were hitting `/robots.txt` and receiving 404 errors — this adds the missing file.

## Changes
- `web/robots.txt` — `Disallow: /` for all user-agents