### PR TITLE
Fix Telegram field hint box

### DIFF
--- a/lib/presentation/pages/auth/subpages/registration_sub_page.dart
+++ b/lib/presentation/pages/auth/subpages/registration_sub_page.dart
@@ -167,7 +167,7 @@ class _RegistrationSubPageState extends State<RegistrationSubPage> {
             AppTextField(
               initialText: null,
               onChange: _registrationCubit.setTelegram,
-              hintText: 'Telegram alias (optional)',
+              hintText: 'Telegram alias',
               inputType: TextInputType.text,
               maxLines: 1,
             ),


### PR DESCRIPTION
Fix misleading message in TG field "Telegram alias (optional)"; telegram field is mandatory.