### PR TITLE
ci: standardize required check naming

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,7 +18,7 @@ env:
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
-  build-flutter:
+  validate:
     runs-on: ubuntu-latest
 
     steps:
@@ -50,7 +50,7 @@ jobs:
           retention-days: 1
 
   build-image:
-    needs: build-flutter
+    needs: validate
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
Closes #118

Standardizes workflow job naming so emitted check contexts match required branch-protection checks.