### PR TITLE
feat(badges): badges section on profile screen

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -13,7 +13,7 @@ import 'package:uuid/uuid.dart';
 import 'application/repositories/auth/auth_repository.dart';
 import 'application/repositories/auth/auth_repository_impl.dart';
 import 'application/repositories/badges/badges_repository.dart';
-import 'application/repositories/badges/badges_repository_mock.dart';
+import 'application/repositories/badges/badges_repository_api.dart';
 import 'application/repositories/auth/otp_login_repository.dart';
 import 'application/repositories/auth/otp_login_repository_impl.dart';
 import 'application/repositories/auth/password_reset_repository.dart';
@@ -175,8 +175,12 @@ class App extends StatelessWidget {
           context.read<LocationsRepository>(),
         ),
       ),
-      // Mocked until BADGES_TICKETS.md #8 (Public badges API) ships.
-      RepositoryProvider<BadgesRepository>(create: (_) => BadgesRepositoryMock()),
+      RepositoryProvider<BadgesRepository>(
+        create: (context) => BadgesRepositoryApi(
+          context.read<Dio>(),
+          context.read<DioOptionsManager>(),
+        ),
+      ),
       // --- BLOCs ---
       BlocProvider(
         create: (context) => EventsListCubit(context.read<EventsRepository>()),

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -216,3 +216,4 @@ class App extends StatelessWidget {
     ),
   );
 }
+

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -44,6 +44,7 @@ import 'data/token/token_provider.dart';
 import 'data/token/token_provider_impl.dart';
 import 'data/users/users_gateway.dart';
 import 'data/users/users_gateway_impl.dart';
+import 'presentation/blocs/badges/badges_cubit.dart';
 import 'presentation/blocs/events_list/events_list_cubit.dart';
 import 'presentation/blocs/profile/profile_cubit.dart';
 import 'presentation/common/constants/app_colors.dart';
@@ -185,6 +186,9 @@ class App extends StatelessWidget {
           ctx.read<UsersRepository>(),
           ctx.read<EventsRepository>(),
         ),
+      ),
+      BlocProvider(
+        create: (ctx) => BadgesCubit(ctx.read<BadgesRepository>())..loadMine(),
       ),
     ],
     child: Builder(

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -12,6 +12,8 @@ import 'package:ui_alumni_mobile/data/map/map_gateway_impl.dart';
 import 'package:uuid/uuid.dart';
 import 'application/repositories/auth/auth_repository.dart';
 import 'application/repositories/auth/auth_repository_impl.dart';
+import 'application/repositories/badges/badges_repository.dart';
+import 'application/repositories/badges/badges_repository_mock.dart';
 import 'application/repositories/auth/otp_login_repository.dart';
 import 'application/repositories/auth/otp_login_repository_impl.dart';
 import 'application/repositories/auth/password_reset_repository.dart';
@@ -172,6 +174,8 @@ class App extends StatelessWidget {
           context.read<LocationsRepository>(),
         ),
       ),
+      // Mocked until BADGES_TICKETS.md #8 (Public badges API) ships.
+      RepositoryProvider<BadgesRepository>(create: (_) => BadgesRepositoryMock()),
       // --- BLOCs ---
       BlocProvider(
         create: (context) => EventsListCubit(context.read<EventsRepository>()),

--- a/lib/application/models/badge.dart
+++ b/lib/application/models/badge.dart
@@ -1,0 +1,85 @@
+// Plain Dart models (no freezed) for the badges feature.
+// Mirrors the API contract from BADGES_TICKETS.md #8.
+// TODO: convert to freezed when the real API is wired.
+
+import 'package:flutter/foundation.dart';
+
+enum BadgeTier { gold, silver, bronze, special }
+
+@immutable
+class Badge {
+  const Badge({
+    required this.code,
+    required this.name,
+    required this.description,
+    required this.tier,
+    required this.iconKey,
+  });
+
+  final String code;
+  final String name;
+  final String description;
+  final BadgeTier tier;
+  final String iconKey;
+}
+
+@immutable
+class EarnedBadge {
+  const EarnedBadge({
+    required this.badge,
+    required this.awardedAt,
+    this.metadata = const {},
+  });
+
+  final Badge badge;
+  final DateTime awardedAt;
+  final Map<String, dynamic> metadata;
+
+  // For Local Legend: returns "Dubai · 2025" when metadata holds them.
+  String? get metadataLabel {
+    final city = metadata['city'];
+    final year = metadata['year'];
+    if (city is String && year is int) {
+      return '$city · $year';
+    }
+    if (city is String) {
+      return city;
+    }
+    return null;
+  }
+}
+
+@immutable
+class LockedBadge {
+  const LockedBadge({
+    required this.badge,
+    required this.progress,
+    required this.threshold,
+    required this.metricLabel,
+  });
+
+  final Badge badge;
+  final int progress;
+  final int threshold;
+  final String metricLabel;
+
+  double get progressFraction =>
+      threshold == 0 ? 0.0 : (progress / threshold).clamp(0.0, 1.0);
+}
+
+@immutable
+class BadgesData {
+  const BadgesData({
+    required this.earned,
+    required this.locked,
+    required this.newlyEarned,
+  });
+
+  final List<EarnedBadge> earned;
+  final List<LockedBadge> locked;
+  final List<Badge> newlyEarned;
+
+  bool get isEmpty => earned.isEmpty && locked.isEmpty;
+
+  int get totalCount => earned.length + locked.length;
+}

--- a/lib/application/repositories/badges/badges_repository.dart
+++ b/lib/application/repositories/badges/badges_repository.dart
@@ -1,0 +1,18 @@
+import '../../models/badge.dart';
+
+/// Source of badges for a profile screen.
+///
+/// Currently has only a mocked implementation (BadgesRepositoryMock) since
+/// the backend API (BADGES_TICKETS.md #8) hasn't shipped yet. Swap for a
+/// real implementation that hits `/api/v1/profile/me/badges` once it does.
+abstract class BadgesRepository {
+  /// Earned + locked + newly-earned for the current user.
+  Future<BadgesData> loadMyBadges();
+
+  /// Earned-only for someone else (`/api/v1/users/{id}/badges`).
+  Future<BadgesData> loadFor(String alumniId);
+
+  /// Marks newly-earned badges as seen so the popup doesn't reappear.
+  /// No-op in the mock; calls `POST /profile/me/badges/{badge_id}/seen` for real.
+  Future<void> markSeen(List<String> badgeCodes);
+}

--- a/lib/application/repositories/badges/badges_repository_api.dart
+++ b/lib/application/repositories/badges/badges_repository_api.dart
@@ -39,10 +39,16 @@ class BadgesRepositoryApi implements BadgesRepository {
   @override
   Future<void> markSeen(List<String> badgeCodes) async {
     final opts = _options.opts();
+    // Best-effort: a failed mark-seen should NOT kill the popup chain. Worst
+    // case the badge re-appears in newlyEarned next time, which is fine.
     await Future.wait(
-      badgeCodes.map(
-        (code) => _dio.post<void>('$_base/me/$code/seen', options: opts),
-      ),
+      badgeCodes.map((code) async {
+        try {
+          await _dio.post<void>('$_base/me/$code/seen', options: opts);
+        } catch (_) {
+          // ignore: we still want to advance the popup chain
+        }
+      }),
     );
   }
 

--- a/lib/application/repositories/badges/badges_repository_api.dart
+++ b/lib/application/repositories/badges/badges_repository_api.dart
@@ -1,0 +1,98 @@
+import 'package:dio/dio.dart';
+
+import '../../../data/common/dio_options_manager.dart';
+import '../../models/badge.dart';
+import 'badges_repository.dart';
+
+/// Hits the real backend at `/api/v1/badges/*`.
+/// Swap [BadgesRepositoryMock] for this in `app.dart` once the API is up.
+class BadgesRepositoryApi implements BadgesRepository {
+  BadgesRepositoryApi(this._dio, this._options);
+
+  final Dio _dio;
+  final DioOptionsManager _options;
+
+  static const _base = '/api/v1/badges';
+
+  @override
+  Future<BadgesData> loadMyBadges() async {
+    final res = await _dio.get<Map<String, dynamic>>(
+      '$_base/me',
+      options: _options.opts(),
+    );
+    return _parseFull(res.data!);
+  }
+
+  @override
+  Future<BadgesData> loadFor(String alumniId) async {
+    final res = await _dio.get<Map<String, dynamic>>(
+      '$_base/users/$alumniId',
+      options: _options.opts(),
+    );
+    return BadgesData(
+      earned: _parseEarned(res.data!['earned'] as List),
+      locked: const [],
+      newlyEarned: const [],
+    );
+  }
+
+  @override
+  Future<void> markSeen(List<String> badgeCodes) async {
+    final opts = _options.opts();
+    await Future.wait(
+      badgeCodes.map(
+        (code) => _dio.post<void>('$_base/me/$code/seen', options: opts),
+      ),
+    );
+  }
+
+  // ─── parsers ───────────────────────────────────────────────────────────
+
+  static BadgesData _parseFull(Map<String, dynamic> json) => BadgesData(
+    earned: _parseEarned(json['earned'] as List? ?? []),
+    locked: _parseLocked(json['locked'] as List? ?? []),
+    newlyEarned: _parseBadgeList(json['newly_earned'] as List? ?? []),
+  );
+
+  static List<EarnedBadge> _parseEarned(List raw) => raw
+      .cast<Map<String, dynamic>>()
+      .map(
+        (j) => EarnedBadge(
+          badge: _parseBadge(j),
+          awardedAt: DateTime.parse(j['awarded_at'] as String),
+          metadata: Map<String, dynamic>.from(j['extra'] as Map? ?? {}),
+        ),
+      )
+      .toList();
+
+  static List<LockedBadge> _parseLocked(List raw) => raw
+      .cast<Map<String, dynamic>>()
+      .map(
+        (j) => LockedBadge(
+          badge: _parseBadge(j),
+          progress: (j['progress'] as num).toInt(),
+          threshold: (j['threshold'] as num).toInt(),
+          metricLabel: j['metric_label'] as String,
+        ),
+      )
+      .toList();
+
+  static List<Badge> _parseBadgeList(List raw) =>
+      raw.cast<Map<String, dynamic>>().map(_parseBadge).toList();
+
+  static Badge _parseBadge(Map<String, dynamic> j) => Badge(
+    code: j['code'] as String,
+    name: j['name'] as String,
+    description: j['description'] as String,
+    tier: _parseTier(j['tier'] as String),
+    iconKey: j['icon_key'] as String,
+  );
+
+  static BadgeTier _parseTier(String t) => switch (t) {
+    'gold' => BadgeTier.gold,
+    'silver' => BadgeTier.silver,
+    'bronze' => BadgeTier.bronze,
+    _ => BadgeTier.special,
+  };
+}
+

--- a/lib/application/repositories/badges/badges_repository_mock.dart
+++ b/lib/application/repositories/badges/badges_repository_mock.dart
@@ -1,0 +1,188 @@
+import '../../models/badge.dart';
+import 'badges_repository.dart';
+
+/// In-memory mock matching the 12 doable badges from the catalog.
+/// Replace with a real impl once the backend API exists.
+class BadgesRepositoryMock implements BadgesRepository {
+  final Set<String> _seen = {};
+
+  static const _pioneer = Badge(
+    code: 'pioneer',
+    name: 'Pioneer',
+    description:
+        'Among the first 100 alumni to pin their location on the map.',
+    tier: BadgeTier.special,
+    iconKey: 'flag',
+  );
+  static const _localLegend = Badge(
+    code: 'local_legend',
+    name: 'Local Legend',
+    description: 'Most events attended in a single city in a given year.',
+    tier: BadgeTier.gold,
+    iconKey: 'crown',
+  );
+  static const _foundingHost = Badge(
+    code: 'founding_host',
+    name: 'Founding Host',
+    description: 'Created the first alumni event in a city.',
+    tier: BadgeTier.gold,
+    iconKey: 'flag',
+  );
+  static const _networker = Badge(
+    code: 'networker',
+    name: 'Networker',
+    description: 'Attended 5+ alumni events.',
+    tier: BadgeTier.bronze,
+    iconKey: 'people',
+  );
+  static const _hostWithTheMost = Badge(
+    code: 'host_with_the_most',
+    name: 'Host with the most',
+    description: 'Organized 3+ events in different cities.',
+    tier: BadgeTier.silver,
+    iconKey: 'trophy',
+  );
+  static const _rainmaker = Badge(
+    code: 'rainmaker',
+    name: 'Rainmaker',
+    description: 'An event you created had 20+ attendees.',
+    tier: BadgeTier.silver,
+    iconKey: 'spark',
+  );
+  static const _crossCity = Badge(
+    code: 'cross_city_commuter',
+    name: 'Cross-city commuter',
+    description:
+        'Attended an event in a city different from your home city.',
+    tier: BadgeTier.bronze,
+    iconKey: 'travel',
+  );
+  static const _innopolisOg = Badge(
+    code: 'innopolis_og',
+    name: 'Innopolis OG',
+    description: 'Graduated from one of the first cohorts (2014–2019).',
+    tier: BadgeTier.gold,
+    iconKey: 'graduation',
+  );
+  static const _profilePro = Badge(
+    code: 'profile_pro',
+    name: 'Profile Pro',
+    description:
+        'Completed all profile fields: photo, location, biography, graduation year, Telegram.',
+    tier: BadgeTier.bronze,
+    iconKey: 'profile_check',
+  );
+  static const _badgeCollector = Badge(
+    code: 'badge_collector',
+    name: 'Badge Collector',
+    description: 'Earned 10+ badges.',
+    tier: BadgeTier.gold,
+    iconKey: 'collection',
+  );
+  static const _openSource = Badge(
+    code: 'open_source_contributor',
+    name: 'Open Source Contributor',
+    description: "Contributed to the platform's open-source codebase.",
+    tier: BadgeTier.silver,
+    iconKey: 'code',
+  );
+  static const _suggestionBox = Badge(
+    code: 'suggestion_box',
+    name: 'Suggestion Box',
+    description: 'Submitted a badge or feature idea that got implemented.',
+    tier: BadgeTier.special,
+    iconKey: 'lightbulb',
+  );
+
+  @override
+  Future<BadgesData> loadMyBadges() async {
+    await Future<void>.delayed(const Duration(milliseconds: 200));
+    final awarded = DateTime.now().subtract(const Duration(days: 14));
+    return BadgesData(
+      earned: [
+        EarnedBadge(badge: _innopolisOg, awardedAt: awarded),
+        EarnedBadge(
+          badge: _networker,
+          awardedAt: awarded.add(const Duration(days: 4)),
+        ),
+        EarnedBadge(
+          badge: _hostWithTheMost,
+          awardedAt: awarded.add(const Duration(days: 8)),
+        ),
+        EarnedBadge(
+          badge: _localLegend,
+          awardedAt: awarded.add(const Duration(days: 10)),
+          metadata: const {'city': 'Innopolis', 'year': 2025},
+        ),
+      ],
+      locked: const [
+        LockedBadge(
+          badge: _rainmaker,
+          progress: 14,
+          threshold: 20,
+          metricLabel: 'attendees on biggest hosted event',
+        ),
+        LockedBadge(
+          badge: _profilePro,
+          progress: 4,
+          threshold: 5,
+          metricLabel: 'profile fields completed',
+        ),
+        LockedBadge(
+          badge: _crossCity,
+          progress: 0,
+          threshold: 1,
+          metricLabel: 'events attended outside home city',
+        ),
+        LockedBadge(
+          badge: _badgeCollector,
+          progress: 4,
+          threshold: 10,
+          metricLabel: 'badges earned',
+        ),
+        LockedBadge(
+          badge: _pioneer,
+          progress: 0,
+          threshold: 1,
+          metricLabel: 'location pinned on the map',
+        ),
+        LockedBadge(
+          badge: _foundingHost,
+          progress: 0,
+          threshold: 1,
+          metricLabel: 'event created as first in a city',
+        ),
+        LockedBadge(
+          badge: _openSource,
+          progress: 0,
+          threshold: 1,
+          metricLabel: 'awarded by an admin',
+        ),
+        LockedBadge(
+          badge: _suggestionBox,
+          progress: 0,
+          threshold: 1,
+          metricLabel: 'awarded by an admin',
+        ),
+      ],
+      newlyEarned: _seen.contains(_localLegend.code)
+          ? const []
+          : const [_localLegend],
+    );
+  }
+
+  @override
+  Future<BadgesData> loadFor(String alumniId) async {
+    final all = await loadMyBadges();
+    return BadgesData(
+      earned: all.earned,
+      locked: const [],
+      newlyEarned: const [],
+    );
+  }
+
+  @override
+  Future<void> markSeen(List<String> badgeCodes) async {
+    _seen.addAll(badgeCodes);
+  }
+}

--- a/lib/presentation/blocs/badges/badges_cubit.dart
+++ b/lib/presentation/blocs/badges/badges_cubit.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_bloc/flutter_bloc.dart';
 
+import '../../../application/models/badge.dart';
 import '../../../application/repositories/badges/badges_repository.dart';
 import '../../common/models/loaded_state.dart';
 import '../models/badges_state.dart';
@@ -31,5 +32,23 @@ class BadgesCubit extends Cubit<BadgesState> {
 
   Future<void> markSeen(List<String> badgeCodes) async {
     await _repo.markSeen(badgeCodes);
+    // Strip these codes from newlyEarned in the cubit state so the popup
+    // doesn't re-trigger on the next read of the same cached data.
+    if (state.badges case LoadedStateData<BadgesData>(:final data)) {
+      final filtered = data.newlyEarned
+          .where((b) => !badgeCodes.contains(b.code))
+          .toList();
+      emit(
+        state.copyWith(
+          badges: LoadedState.data(
+            BadgesData(
+              earned: data.earned,
+              locked: data.locked,
+              newlyEarned: filtered,
+            ),
+          ),
+        ),
+      );
+    }
   }
 }

--- a/lib/presentation/blocs/badges/badges_cubit.dart
+++ b/lib/presentation/blocs/badges/badges_cubit.dart
@@ -1,0 +1,35 @@
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+import '../../../application/repositories/badges/badges_repository.dart';
+import '../../common/models/loaded_state.dart';
+import '../models/badges_state.dart';
+
+class BadgesCubit extends Cubit<BadgesState> {
+  BadgesCubit(this._repo) : super(const BadgesState());
+
+  final BadgesRepository _repo;
+
+  Future<void> loadMine() async {
+    emit(state.copyWith(badges: const LoadedState.loading()));
+    try {
+      final data = await _repo.loadMyBadges();
+      emit(state.copyWith(badges: LoadedState.data(data)));
+    } catch (e) {
+      emit(state.copyWith(badges: LoadedState.error(e.toString())));
+    }
+  }
+
+  Future<void> loadFor(String alumniId) async {
+    emit(state.copyWith(badges: const LoadedState.loading()));
+    try {
+      final data = await _repo.loadFor(alumniId);
+      emit(state.copyWith(badges: LoadedState.data(data)));
+    } catch (e) {
+      emit(state.copyWith(badges: LoadedState.error(e.toString())));
+    }
+  }
+
+  Future<void> markSeen(List<String> badgeCodes) async {
+    await _repo.markSeen(badgeCodes);
+  }
+}

--- a/lib/presentation/blocs/models/badges_state.dart
+++ b/lib/presentation/blocs/models/badges_state.dart
@@ -1,0 +1,14 @@
+import 'package:flutter/foundation.dart';
+
+import '../../../application/models/badge.dart';
+import '../../common/models/loaded_state.dart';
+
+@immutable
+class BadgesState {
+  const BadgesState({this.badges = const LoadedState.init()});
+
+  final LoadedState<BadgesData> badges;
+
+  BadgesState copyWith({LoadedState<BadgesData>? badges}) =>
+      BadgesState(badges: badges ?? this.badges);
+}

--- a/lib/presentation/pages/event/widgets/event_content.dart
+++ b/lib/presentation/pages/event/widgets/event_content.dart
@@ -13,6 +13,7 @@ import '../../../../util/currency_formatter.dart';
 import '../../../../util/num_formatter.dart';
 import '../../../blocs/models/one_event_state.dart';
 import '../../../blocs/one_event/one_event_cubit.dart';
+import '../../../blocs/badges/badges_cubit.dart';
 import '../../../blocs/profile/profile_cubit.dart';
 import '../../../common/constants/app_text_styles.dart';
 import '../../../common/widgets/app_button.dart';
@@ -93,9 +94,13 @@ class _Cover extends StatelessWidget {
 
   Future<void> _participate(BuildContext context) async {
     final profileCubit = context.read<ProfileCubit>();
+    final badgesCubit = context.read<BadgesCubit>();
     await context.read<OneEventCubit>().participate();
     // Mark this one is updated
     await profileCubit.updateParticipatedEvents();
+    // Re-fetch badges so any newly-earned badge shows the celebratory popup
+    // immediately — the global listener in app.dart handles the popup itself.
+    await badgesCubit.loadMine();
   }
 
   Future<void> _leave(BuildContext context) async {

--- a/lib/presentation/pages/profile/profile_page.dart
+++ b/lib/presentation/pages/profile/profile_page.dart
@@ -6,11 +6,9 @@ import 'package:ui_alumni_mobile/presentation/common/widgets/nav_button.dart';
 
 import '../../../application/models/profile.dart';
 // import '../../../application/repositories/auth/telegram_verify_repository.dart'; // temporarily disabled
-import '../../../application/repositories/badges/badges_repository.dart';
 import '../../../application/repositories/events/events_repository.dart';
 import '../../../application/repositories/reporter/reporter.dart';
 import '../../../application/repositories/users/users_repository.dart';
-import '../../blocs/badges/badges_cubit.dart';
 import '../../blocs/models/profile_state.dart';
 import '../../blocs/profile/profile_cubit.dart';
 // import '../../blocs/telegram_verify/telegram_verify_cubit.dart'; // temporarily disabled
@@ -37,9 +35,6 @@ class ProfilePage extends StatefulWidget implements AutoRouteWrapper {
       BlocProvider(
         create: (ctx) =>
             ProfileCubit(ctx.read<UsersRepository>(), ctx.read<EventsRepository>()),
-      ),
-      BlocProvider(
-        create: (ctx) => BadgesCubit(ctx.read<BadgesRepository>())..loadMine(),
       ),
       // Telegram verification temporarily disabled — re-enable when bot is ready
       // BlocProvider(

--- a/lib/presentation/pages/profile/profile_page.dart
+++ b/lib/presentation/pages/profile/profile_page.dart
@@ -9,6 +9,7 @@ import '../../../application/models/profile.dart';
 import '../../../application/repositories/events/events_repository.dart';
 import '../../../application/repositories/reporter/reporter.dart';
 import '../../../application/repositories/users/users_repository.dart';
+import '../../blocs/badges/badges_cubit.dart';
 import '../../blocs/models/profile_state.dart';
 import '../../blocs/profile/profile_cubit.dart';
 // import '../../blocs/telegram_verify/telegram_verify_cubit.dart'; // temporarily disabled
@@ -84,6 +85,7 @@ class _ProfilePageState extends State<ProfilePage> {
       listener: (context, state) {
         _cubit.loadOwnedEvents();
         _cubit.loadParticipatedEvents();
+        context.read<BadgesCubit>().loadMine();
       },
       builder: (context, state) => AppScaffold(
         title: 'Profile',

--- a/lib/presentation/pages/profile/profile_page.dart
+++ b/lib/presentation/pages/profile/profile_page.dart
@@ -6,9 +6,11 @@ import 'package:ui_alumni_mobile/presentation/common/widgets/nav_button.dart';
 
 import '../../../application/models/profile.dart';
 // import '../../../application/repositories/auth/telegram_verify_repository.dart'; // temporarily disabled
+import '../../../application/repositories/badges/badges_repository.dart';
 import '../../../application/repositories/events/events_repository.dart';
 import '../../../application/repositories/reporter/reporter.dart';
 import '../../../application/repositories/users/users_repository.dart';
+import '../../blocs/badges/badges_cubit.dart';
 import '../../blocs/models/profile_state.dart';
 import '../../blocs/profile/profile_cubit.dart';
 // import '../../blocs/telegram_verify/telegram_verify_cubit.dart'; // temporarily disabled
@@ -35,6 +37,9 @@ class ProfilePage extends StatefulWidget implements AutoRouteWrapper {
       BlocProvider(
         create: (ctx) =>
             ProfileCubit(ctx.read<UsersRepository>(), ctx.read<EventsRepository>()),
+      ),
+      BlocProvider(
+        create: (ctx) => BadgesCubit(ctx.read<BadgesRepository>())..loadMine(),
       ),
       // Telegram verification temporarily disabled — re-enable when bot is ready
       // BlocProvider(

--- a/lib/presentation/pages/profile/widgets/badge_earned_popup.dart
+++ b/lib/presentation/pages/profile/widgets/badge_earned_popup.dart
@@ -1,0 +1,346 @@
+import 'package:flutter/material.dart' hide Badge;
+
+import '../../../../application/models/badge.dart';
+import '../../../blocs/badges/badges_cubit.dart';
+import '../../../common/constants/app_colors.dart';
+import '../../../common/constants/app_text_styles.dart';
+
+/// Celebratory modal shown after [BadgesCubit] reports newly-earned badges.
+///
+/// Matches `mockups/10-badge-earned-popup.png`. Stacks across multiple badges:
+/// each dismiss calls [BadgesCubit.markSeen] for that code and (if more remain)
+/// pushes the next badge as a new dialog.
+class BadgeEarnedPopup {
+  /// Shows the popup chain. Returns `true` if the user tapped
+  /// "View on my profile" on the LAST popup — the caller should then switch
+  /// to the Profile tab. Otherwise returns `false`.
+  static Future<bool> show(
+    BuildContext context,
+    BadgesCubit cubit,
+    List<Badge> badges,
+  ) async {
+    var wantsProfile = false;
+    for (final badge in badges) {
+      if (!context.mounted) {
+        return wantsProfile;
+      }
+      final result = await showDialog<bool>(
+        context: context,
+        barrierColor: Colors.black54,
+        builder: (_) => _Card(badge: badge),
+      );
+      wantsProfile = result ?? false;
+      await cubit.markSeen([badge.code]);
+    }
+    return wantsProfile;
+  }
+}
+
+class _Card extends StatelessWidget {
+  const _Card({required this.badge});
+
+  final Badge badge;
+
+  @override
+  Widget build(BuildContext context) => Dialog(
+    backgroundColor: Colors.transparent,
+    insetPadding: const EdgeInsets.symmetric(horizontal: 24, vertical: 32),
+    child: ConstrainedBox(
+      constraints: const BoxConstraints(maxWidth: 380),
+      child: Stack(
+        clipBehavior: Clip.none,
+        children: [
+          Container(
+            padding: const EdgeInsets.fromLTRB(24, 32, 24, 24),
+            decoration: BoxDecoration(
+              color: Colors.white,
+              borderRadius: BorderRadius.circular(20),
+              boxShadow: const [
+                BoxShadow(
+                  color: Color(0x66000000),
+                  blurRadius: 24,
+                  offset: Offset(0, 4),
+                ),
+              ],
+            ),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Text(
+                  'BADGE UNLOCKED',
+                  style: AppTextStyles.caption.copyWith(
+                    color: AppColors.primary,
+                    fontWeight: FontWeight.w800,
+                    letterSpacing: 1.4,
+                  ),
+                ),
+                const SizedBox(height: 6),
+                Text(
+                  'Congratulations!',
+                  style: AppTextStyles.subtitle.copyWith(
+                    fontSize: 26,
+                    color: AppColors.darkGray,
+                    fontWeight: FontWeight.w800,
+                  ),
+                ),
+                const SizedBox(height: 22),
+                _Hero(badge: badge),
+                const SizedBox(height: 14),
+                _TierPill(tier: badge.tier),
+                const SizedBox(height: 14),
+                Text(
+                  badge.name,
+                  style: AppTextStyles.subtitle.copyWith(
+                    fontSize: 22,
+                    color: AppColors.darkGray,
+                    fontWeight: FontWeight.w800,
+                  ),
+                  textAlign: TextAlign.center,
+                ),
+                const SizedBox(height: 10),
+                Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 6),
+                  child: Text(
+                    badge.description,
+                    style: AppTextStyles.body.copyWith(
+                      color: AppColors.gray30,
+                      fontSize: 14,
+                      height: 1.5,
+                    ),
+                    textAlign: TextAlign.center,
+                  ),
+                ),
+                const SizedBox(height: 22),
+                SizedBox(
+                  width: double.infinity,
+                  child: FilledButton(
+                    style: FilledButton.styleFrom(
+                      backgroundColor: AppColors.primary,
+                      padding: const EdgeInsets.symmetric(vertical: 14),
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(8),
+                      ),
+                    ),
+                    onPressed: () => Navigator.of(context).pop(true),
+                    child: Text(
+                      'View on my profile',
+                      style: AppTextStyles.body.copyWith(
+                        color: Colors.white,
+                        fontWeight: FontWeight.w700,
+                        fontSize: 15,
+                      ),
+                    ),
+                  ),
+                ),
+                TextButton(
+                  onPressed: () => Navigator.of(context).pop(false),
+                  child: Text(
+                    'Maybe later',
+                    style: AppTextStyles.body.copyWith(
+                      color: AppColors.gray50,
+                      fontWeight: FontWeight.w600,
+                      fontSize: 13,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+          // Confetti scattered on top of the card.
+          ..._confetti(),
+          // Close X
+          Positioned(
+            top: 14,
+            right: 14,
+            child: GestureDetector(
+              onTap: () => Navigator.of(context).pop(false),
+              child: Container(
+                width: 30,
+                height: 30,
+                alignment: Alignment.center,
+                decoration: const BoxDecoration(
+                  shape: BoxShape.circle,
+                  color: Color(0xFFF4F5F7),
+                ),
+                child: const Icon(Icons.close, size: 18, color: AppColors.gray50),
+              ),
+            ),
+          ),
+        ],
+      ),
+    ),
+  );
+
+  List<Widget> _confetti() => const [
+    _Confetti(top: 22, left: 36, color: Color(0xFFF59E0B), rotate: 0.35),
+    _Confetti(top: 42, left: 96, color: Color(0xFF40BA21), circle: true),
+    _Confetti(top: 18, left: 168, color: Color(0xFF3B82F6), rotate: 0.78),
+    _Confetti(top: 56, left: 240, color: Color(0xFFEC4899), rotate: -0.26, size: 10),
+    _Confetti(top: 24, left: 312, color: Color(0xFFF59E0B), circle: true),
+    _Confetti(top: 80, left: 24, color: Color(0xFFA855F7), rotate: 0.61),
+    _Confetti(top: 100, left: 336, color: Color(0xFF22C55E)),
+    _Confetti(top: 144, left: 14, color: Color(0xFFEC4899), circle: true),
+    _Confetti(top: 160, left: 348, color: Color(0xFFF59E0B), rotate: 0.35),
+  ];
+}
+
+class _Hero extends StatelessWidget {
+  const _Hero({required this.badge});
+
+  final Badge badge;
+
+  @override
+  Widget build(BuildContext context) {
+    final ringColors = _tierGradient(badge.tier);
+    final iconBg = _tierIconBg(badge.tier);
+    final iconColor = _tierIconColor(badge.tier);
+    return Stack(
+      alignment: Alignment.center,
+      children: [
+        // Soft glow.
+        Container(
+          width: 220,
+          height: 220,
+          decoration: BoxDecoration(
+            shape: BoxShape.circle,
+            gradient: RadialGradient(
+              colors: [
+                ringColors.first.withValues(alpha: 0.35),
+                Colors.transparent,
+              ],
+            ),
+          ),
+        ),
+        Container(
+          width: 180,
+          height: 180,
+          padding: const EdgeInsets.all(8),
+          decoration: BoxDecoration(
+            shape: BoxShape.circle,
+            gradient: LinearGradient(
+              colors: ringColors,
+              begin: Alignment.topLeft,
+              end: Alignment.bottomRight,
+            ),
+          ),
+          child: Container(
+            decoration: BoxDecoration(shape: BoxShape.circle, color: iconBg),
+            child: Icon(_iconFor(badge.iconKey), color: iconColor, size: 96),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _TierPill extends StatelessWidget {
+  const _TierPill({required this.tier});
+
+  final BadgeTier tier;
+
+  @override
+  Widget build(BuildContext context) => Container(
+    padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 4),
+    decoration: BoxDecoration(
+      color: _tierPillBg(tier),
+      borderRadius: BorderRadius.circular(999),
+    ),
+    child: Text(
+      _tierLabel(tier),
+      style: const TextStyle(
+        color: Colors.white,
+        fontWeight: FontWeight.w800,
+        fontSize: 12,
+        letterSpacing: 1,
+      ),
+    ),
+  );
+}
+
+class _Confetti extends StatelessWidget {
+  const _Confetti({
+    required this.top,
+    required this.left,
+    required this.color,
+    this.rotate = 0,
+    this.circle = false,
+    this.size = 8,
+  });
+
+  final double top;
+  final double left;
+  final Color color;
+  final double rotate;
+  final bool circle;
+  final double size;
+
+  @override
+  Widget build(BuildContext context) => Positioned(
+    top: top,
+    left: left,
+    child: Transform.rotate(
+      angle: rotate,
+      child: Container(
+        width: size,
+        height: size,
+        decoration: BoxDecoration(
+          color: color,
+          borderRadius: BorderRadius.circular(circle ? size : 2),
+        ),
+      ),
+    ),
+  );
+}
+
+// --- Tier helpers (duplicated from badges_section.dart to avoid exposing them
+// as public; keep both in sync for now). ---
+
+List<Color> _tierGradient(BadgeTier t) => switch (t) {
+  BadgeTier.gold => const [Color(0xFFFFD24D), Color(0xFFB58400)],
+  BadgeTier.silver => const [Color(0xFFE2E8F0), Color(0xFF94A3B8)],
+  BadgeTier.bronze => const [Color(0xFFE0925A), Color(0xFF8C4A18)],
+  BadgeTier.special => const [AppColors.primary, Color(0xFF2E8A14)],
+};
+
+Color _tierIconBg(BadgeTier t) => switch (t) {
+  BadgeTier.gold => const Color(0xFFFFF8E7),
+  BadgeTier.silver => const Color(0xFFF1F5F9),
+  BadgeTier.bronze => const Color(0xFFFFF5E6),
+  BadgeTier.special => const Color(0xFFEBFAE5),
+};
+
+Color _tierIconColor(BadgeTier t) => switch (t) {
+  BadgeTier.gold => const Color(0xFFC99A2E),
+  BadgeTier.silver => const Color(0xFF64748B),
+  BadgeTier.bronze => const Color(0xFF8C4A18),
+  BadgeTier.special => AppColors.primary,
+};
+
+Color _tierPillBg(BadgeTier t) => switch (t) {
+  BadgeTier.gold => const Color(0xFFC99A2E),
+  BadgeTier.silver => const Color(0xFF94A3B8),
+  BadgeTier.bronze => const Color(0xFFB45309),
+  BadgeTier.special => AppColors.primary,
+};
+
+String _tierLabel(BadgeTier t) => switch (t) {
+  BadgeTier.gold => 'GOLD',
+  BadgeTier.silver => 'SILVER',
+  BadgeTier.bronze => 'BRONZE',
+  BadgeTier.special => 'SPECIAL',
+};
+
+IconData _iconFor(String key) => switch (key) {
+  'flag' => Icons.flag,
+  'crown' => Icons.emoji_events,
+  'people' => Icons.people,
+  'trophy' => Icons.emoji_events,
+  'spark' => Icons.bolt,
+  'travel' => Icons.flight_takeoff,
+  'graduation' => Icons.school,
+  'profile_check' => Icons.verified_user,
+  'collection' => Icons.collections,
+  'code' => Icons.code,
+  'lightbulb' => Icons.lightbulb,
+  _ => Icons.star,
+};

--- a/lib/presentation/pages/profile/widgets/badges_section.dart
+++ b/lib/presentation/pages/profile/widgets/badges_section.dart
@@ -8,20 +8,52 @@ import '../../../common/constants/app_colors.dart';
 import '../../../common/constants/app_text_styles.dart';
 import '../../../common/models/loaded_state.dart';
 import '../../../common/widgets/app_loader.dart';
-import '../../../common/widgets/titled_item.dart';
+import '../../../common/constants/app_text_styles.dart' show AppTextStyles;
 
 const _badgeWidth = 96.0;
 const _ringSize = 96.0;
 
-class BadgesSection extends StatelessWidget {
+class BadgesSection extends StatefulWidget {
   const BadgesSection({super.key});
 
   @override
-  Widget build(BuildContext context) => TitledItem(
-    title: 'Badges',
-    child: BlocBuilder<BadgesCubit, BadgesState>(
-      buildWhen: (p, c) => p.badges != c.badges,
-      builder: (context, state) => switch (state.badges) {
+  State<BadgesSection> createState() => _BadgesSectionState();
+}
+
+class _BadgesSectionState extends State<BadgesSection> {
+  @override
+  void initState() {
+    super.initState();
+    // Re-fetch every time the section mounts so newly-earned badges show up
+    // after the user takes an action elsewhere (e.g. joining an event).
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) {
+        context.read<BadgesCubit>().loadMine();
+      }
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) => Column(
+    crossAxisAlignment: CrossAxisAlignment.stretch,
+    children: [
+      Row(
+        children: [
+          Expanded(
+            child: Text('Badges', style: AppTextStyles.subtitle),
+          ),
+          IconButton(
+            visualDensity: VisualDensity.compact,
+            tooltip: 'Refresh',
+            icon: const Icon(Icons.refresh, color: AppColors.gray50, size: 20),
+            onPressed: () => context.read<BadgesCubit>().loadMine(),
+          ),
+        ],
+      ),
+      const SizedBox(height: 4),
+      BlocBuilder<BadgesCubit, BadgesState>(
+        buildWhen: (p, c) => p.badges != c.badges,
+        builder: (context, state) => switch (state.badges) {
         LoadedStateData<BadgesData>(:final data) when data.isEmpty => Padding(
           padding: const EdgeInsets.all(16),
           child: Text(
@@ -44,7 +76,8 @@ class BadgesSection extends StatelessWidget {
           child: Center(child: AppLoader()),
         ),
       },
-    ),
+      ),
+    ],
   );
 }
 

--- a/lib/presentation/pages/profile/widgets/badges_section.dart
+++ b/lib/presentation/pages/profile/widgets/badges_section.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:flutter/material.dart' hide Badge;
 import 'package:flutter_bloc/flutter_bloc.dart';
 
 import '../../../../application/models/badge.dart';

--- a/lib/presentation/pages/profile/widgets/badges_section.dart
+++ b/lib/presentation/pages/profile/widgets/badges_section.dart
@@ -188,26 +188,80 @@ class _LockedTile extends StatelessWidget {
                 ),
               ),
             ),
-            // Top-right info pill.
+            // Top-right info pill — hover (web/desktop) or long-press (mobile)
+            // surfaces a tooltip explaining how to earn the badge.
             Positioned(
               right: -2,
               top: -2,
-              child: Container(
-                width: 24,
-                height: 24,
-                alignment: Alignment.center,
-                decoration: BoxDecoration(
-                  shape: BoxShape.circle,
-                  color: AppColors.primary,
-                  border: Border.all(color: Colors.white, width: 2),
+              child: Tooltip(
+                richMessage: TextSpan(
+                  children: [
+                    TextSpan(
+                      text: '${locked.badge.name}\n',
+                      style: const TextStyle(
+                        color: Colors.white,
+                        fontWeight: FontWeight.w800,
+                        fontSize: 13,
+                      ),
+                    ),
+                    TextSpan(
+                      text: '${locked.badge.description}\n',
+                      style: const TextStyle(
+                        color: Colors.white,
+                        fontSize: 12,
+                        height: 1.35,
+                      ),
+                    ),
+                    TextSpan(
+                      text: locked.threshold <= 1
+                          ? '\nNot yet started'
+                          : '\nProgress: ${locked.progress} / ${locked.threshold} ${locked.metricLabel}',
+                      style: const TextStyle(
+                        color: Color(0xFFC7F0BB),
+                        fontSize: 11,
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                  ],
                 ),
-                child: const Text(
-                  'i',
-                  style: TextStyle(
-                    color: Colors.white,
-                    fontWeight: FontWeight.w800,
-                    fontSize: 13,
-                    height: 1,
+                preferBelow: false,
+                waitDuration: const Duration(milliseconds: 300),
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 12,
+                  vertical: 10,
+                ),
+                margin: const EdgeInsets.symmetric(horizontal: 8),
+                decoration: BoxDecoration(
+                  color: AppColors.darkGray,
+                  borderRadius: BorderRadius.circular(8),
+                  boxShadow: const [
+                    BoxShadow(
+                      color: Color(0x33000000),
+                      blurRadius: 8,
+                      offset: Offset(0, 2),
+                    ),
+                  ],
+                ),
+                child: MouseRegion(
+                  cursor: SystemMouseCursors.help,
+                  child: Container(
+                    width: 24,
+                    height: 24,
+                    alignment: Alignment.center,
+                    decoration: BoxDecoration(
+                      shape: BoxShape.circle,
+                      color: AppColors.primary,
+                      border: Border.all(color: Colors.white, width: 2),
+                    ),
+                    child: const Text(
+                      'i',
+                      style: TextStyle(
+                        color: Colors.white,
+                        fontWeight: FontWeight.w800,
+                        fontSize: 13,
+                        height: 1,
+                      ),
+                    ),
                   ),
                 ),
               ),

--- a/lib/presentation/pages/profile/widgets/badges_section.dart
+++ b/lib/presentation/pages/profile/widgets/badges_section.dart
@@ -1,0 +1,331 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+import '../../../../application/models/badge.dart';
+import '../../../blocs/badges/badges_cubit.dart';
+import '../../../blocs/models/badges_state.dart';
+import '../../../common/constants/app_colors.dart';
+import '../../../common/constants/app_text_styles.dart';
+import '../../../common/models/loaded_state.dart';
+import '../../../common/widgets/app_loader.dart';
+import '../../../common/widgets/titled_item.dart';
+
+const _badgeWidth = 96.0;
+const _ringSize = 96.0;
+
+class BadgesSection extends StatelessWidget {
+  const BadgesSection({super.key});
+
+  @override
+  Widget build(BuildContext context) => TitledItem(
+    title: 'Badges',
+    child: BlocBuilder<BadgesCubit, BadgesState>(
+      buildWhen: (p, c) => p.badges != c.badges,
+      builder: (context, state) => switch (state.badges) {
+        LoadedStateData<BadgesData>(:final data) when data.isEmpty => Padding(
+          padding: const EdgeInsets.all(16),
+          child: Text(
+            'No badges yet — attend events to start unlocking them.',
+            style: AppTextStyles.caption,
+            textAlign: TextAlign.center,
+          ),
+        ),
+        LoadedStateData<BadgesData>(:final data) => _Row(data: data),
+        LoadedStateError(:final error) => Padding(
+          padding: const EdgeInsets.all(16),
+          child: Text(
+            error,
+            style: AppTextStyles.caption,
+            textAlign: TextAlign.center,
+          ),
+        ),
+        _ => const Padding(
+          padding: EdgeInsets.all(16),
+          child: Center(child: AppLoader()),
+        ),
+      },
+    ),
+  );
+}
+
+class _Row extends StatelessWidget {
+  const _Row({required this.data});
+
+  final BadgesData data;
+
+  @override
+  Widget build(BuildContext context) => SingleChildScrollView(
+    physics: const BouncingScrollPhysics(),
+    scrollDirection: Axis.horizontal,
+    child: Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        for (final e in data.earned) ...[
+          _EarnedTile(earned: e),
+          const SizedBox(width: 10),
+        ],
+        for (final l in data.locked) ...[
+          _LockedTile(locked: l),
+          const SizedBox(width: 10),
+        ],
+      ],
+    ),
+  );
+}
+
+class _EarnedTile extends StatelessWidget {
+  const _EarnedTile({required this.earned});
+
+  final EarnedBadge earned;
+
+  @override
+  Widget build(BuildContext context) {
+    final ringColors = _tierGradient(earned.badge.tier);
+    return SizedBox(
+      width: _badgeWidth,
+      child: Column(
+        children: [
+          Container(
+            width: _ringSize,
+            height: _ringSize,
+            padding: const EdgeInsets.all(4),
+            decoration: BoxDecoration(
+              shape: BoxShape.circle,
+              gradient: LinearGradient(
+                colors: ringColors,
+                begin: Alignment.topLeft,
+                end: Alignment.bottomRight,
+              ),
+            ),
+            child: Container(
+              decoration: BoxDecoration(
+                shape: BoxShape.circle,
+                color: _tierIconBg(earned.badge.tier),
+              ),
+              child: Icon(
+                _iconFor(earned.badge.iconKey),
+                color: _tierIconColor(earned.badge.tier),
+                size: 44,
+              ),
+            ),
+          ),
+          const SizedBox(height: 6),
+          _TierPill(tier: earned.badge.tier),
+          const SizedBox(height: 4),
+          Text(
+            earned.badge.name,
+            style: AppTextStyles.caption.copyWith(
+              color: AppColors.darkGray,
+              fontWeight: FontWeight.w600,
+            ),
+            textAlign: TextAlign.center,
+            maxLines: 2,
+            overflow: TextOverflow.ellipsis,
+          ),
+          if (earned.metadataLabel case final label?)
+            Text(
+              label,
+              style: AppTextStyles.caption.copyWith(color: AppColors.gray50),
+              textAlign: TextAlign.center,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+class _LockedTile extends StatelessWidget {
+  const _LockedTile({required this.locked});
+
+  final LockedBadge locked;
+
+  @override
+  Widget build(BuildContext context) => SizedBox(
+    width: _badgeWidth,
+    child: Column(
+      children: [
+        Stack(
+          clipBehavior: Clip.none,
+          children: [
+            Container(
+              width: _ringSize,
+              height: _ringSize,
+              padding: const EdgeInsets.all(4),
+              decoration: BoxDecoration(
+                shape: BoxShape.circle,
+                border: Border.all(color: AppColors.gray80, width: 2),
+              ),
+              child: Container(
+                decoration: const BoxDecoration(
+                  shape: BoxShape.circle,
+                  color: AppColors.gray90,
+                ),
+                child: Icon(
+                  _iconFor(locked.badge.iconKey),
+                  color: AppColors.gray80,
+                  size: 38,
+                ),
+              ),
+            ),
+            // Bottom-right lock chip.
+            Positioned(
+              right: -2,
+              bottom: -2,
+              child: Container(
+                width: 28,
+                height: 28,
+                decoration: BoxDecoration(
+                  shape: BoxShape.circle,
+                  color: AppColors.gray30,
+                  border: Border.all(color: Colors.white, width: 3),
+                ),
+                child: const Icon(
+                  Icons.lock,
+                  color: Colors.white,
+                  size: 14,
+                ),
+              ),
+            ),
+            // Top-right info pill.
+            Positioned(
+              right: -2,
+              top: -2,
+              child: Container(
+                width: 24,
+                height: 24,
+                alignment: Alignment.center,
+                decoration: BoxDecoration(
+                  shape: BoxShape.circle,
+                  color: AppColors.primary,
+                  border: Border.all(color: Colors.white, width: 2),
+                ),
+                child: const Text(
+                  'i',
+                  style: TextStyle(
+                    color: Colors.white,
+                    fontWeight: FontWeight.w800,
+                    fontSize: 13,
+                    height: 1,
+                  ),
+                ),
+              ),
+            ),
+          ],
+        ),
+        const SizedBox(height: 6),
+        Text(
+          locked.badge.name,
+          style: AppTextStyles.caption.copyWith(
+            color: AppColors.gray50,
+            fontWeight: FontWeight.w600,
+          ),
+          textAlign: TextAlign.center,
+          maxLines: 2,
+          overflow: TextOverflow.ellipsis,
+        ),
+        const SizedBox(height: 4),
+        SizedBox(
+          width: 72,
+          child: ClipRRect(
+            borderRadius: BorderRadius.circular(2),
+            child: LinearProgressIndicator(
+              value: locked.progressFraction,
+              minHeight: 4,
+              backgroundColor: AppColors.gray80,
+              valueColor: const AlwaysStoppedAnimation(AppColors.primary),
+            ),
+          ),
+        ),
+        const SizedBox(height: 2),
+        Text(
+          locked.threshold <= 1 && locked.progress == 0
+              ? 'Not started'
+              : '${locked.progress} / ${locked.threshold}',
+          style: AppTextStyles.caption.copyWith(
+            color: AppColors.gray50,
+            fontSize: 10,
+          ),
+        ),
+      ],
+    ),
+  );
+}
+
+class _TierPill extends StatelessWidget {
+  const _TierPill({required this.tier});
+
+  final BadgeTier tier;
+
+  @override
+  Widget build(BuildContext context) => Container(
+    padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+    decoration: BoxDecoration(
+      color: _tierPillBg(tier),
+      borderRadius: BorderRadius.circular(999),
+    ),
+    child: Text(
+      _tierLabel(tier),
+      style: const TextStyle(
+        color: Colors.white,
+        fontWeight: FontWeight.w700,
+        fontSize: 10,
+        letterSpacing: 0.8,
+      ),
+    ),
+  );
+}
+
+// --- Tier styling helpers ---
+
+List<Color> _tierGradient(BadgeTier t) => switch (t) {
+  BadgeTier.gold => const [Color(0xFFFFD24D), Color(0xFFB58400)],
+  BadgeTier.silver => const [Color(0xFFE2E8F0), Color(0xFF94A3B8)],
+  BadgeTier.bronze => const [Color(0xFFE0925A), Color(0xFF8C4A18)],
+  BadgeTier.special => const [AppColors.primary, Color(0xFF2E8A14)],
+};
+
+Color _tierIconBg(BadgeTier t) => switch (t) {
+  BadgeTier.gold => const Color(0xFFFFF8E7),
+  BadgeTier.silver => const Color(0xFFF1F5F9),
+  BadgeTier.bronze => const Color(0xFFFFF5E6),
+  BadgeTier.special => const Color(0xFFEBFAE5),
+};
+
+Color _tierIconColor(BadgeTier t) => switch (t) {
+  BadgeTier.gold => const Color(0xFFC99A2E),
+  BadgeTier.silver => const Color(0xFF64748B),
+  BadgeTier.bronze => const Color(0xFF8C4A18),
+  BadgeTier.special => AppColors.primary,
+};
+
+Color _tierPillBg(BadgeTier t) => switch (t) {
+  BadgeTier.gold => const Color(0xFFC99A2E),
+  BadgeTier.silver => const Color(0xFF94A3B8),
+  BadgeTier.bronze => const Color(0xFFB45309),
+  BadgeTier.special => AppColors.primary,
+};
+
+String _tierLabel(BadgeTier t) => switch (t) {
+  BadgeTier.gold => 'GOLD',
+  BadgeTier.silver => 'SILVER',
+  BadgeTier.bronze => 'BRONZE',
+  BadgeTier.special => 'SPECIAL',
+};
+
+// Map our string icon key to Material icons. SVG assets can swap in later.
+IconData _iconFor(String key) => switch (key) {
+  'flag' => Icons.flag,
+  'crown' => Icons.emoji_events,
+  'people' => Icons.people,
+  'trophy' => Icons.emoji_events,
+  'spark' => Icons.bolt,
+  'travel' => Icons.flight_takeoff,
+  'graduation' => Icons.school,
+  'profile_check' => Icons.verified_user,
+  'collection' => Icons.collections,
+  'code' => Icons.code,
+  'lightbulb' => Icons.lightbulb,
+  _ => Icons.star,
+};

--- a/lib/presentation/pages/profile/widgets/profile_content.dart
+++ b/lib/presentation/pages/profile/widgets/profile_content.dart
@@ -21,6 +21,7 @@ import '../../../common/widgets/event_card.dart';
 import '../../../common/widgets/profile_pic.dart';
 import '../../../common/widgets/titled_item.dart';
 import '../../root/root_page.dart';
+import 'badges_section.dart';
 import 'open_bot_card.dart';
 
 const _eventCardWidth = 200.0;
@@ -118,6 +119,7 @@ class ProfileContent {
               ],
             ),
           ),
+        const BadgesSection(),
         if (personal) const _OwnedEvents(),
         const _ParticipatedEvents(),
         if (personal) const OpenBotCard(),

--- a/lib/presentation/pages/root/root_page.dart
+++ b/lib/presentation/pages/root/root_page.dart
@@ -1,15 +1,21 @@
 import 'package:auto_route/auto_route.dart';
-import 'package:flutter/material.dart';
+import 'package:flutter/material.dart' hide Badge;
+// ignore: implementation_imports — relying on the public auto_route export
 import 'package:flutter_bloc/flutter_bloc.dart';
+import '../../../application/models/badge.dart';
 import '../../../application/repositories/map/map_repository.dart';
 import '../../../application/repositories/reporter/reporter.dart';
+import '../../blocs/badges/badges_cubit.dart';
+import '../../blocs/models/badges_state.dart';
 import '../../blocs/root/root_page_cubit.dart';
 import '../../blocs/pin_locations/pin_locations_cubit.dart';
 import '../../common/constants/app_colors.dart';
+import '../../common/models/loaded_state.dart';
 import '../../common/widgets/app_button.dart';
 import '../events_list/events_list_page.dart';
 import '../map/map_page.dart';
 import '../profile/profile_page.dart';
+import '../profile/widgets/badge_earned_popup.dart';
 
 @RoutePage()
 class RootPage extends StatefulWidget implements AutoRouteWrapper {
@@ -36,6 +42,57 @@ class _RootPageState extends State<RootPage> {
   late final Widget _eventsPage = const EventsListPage();
   late final Widget _mapPage = const MapPage();
   late final Widget _profilePage = const ProfilePage();
+
+  // Popup-chain state. RootPage sits INSIDE the Navigator, so showDialog
+  // works here whereas it'd fail from MaterialApp.builder above the router.
+  final Set<String> _badgesShown = {};
+  bool _popupInFlight = false;
+
+  static List<Badge> _newly(BadgesState s) => switch (s.badges) {
+    LoadedStateData<BadgesData>(:final data) => data.newlyEarned,
+    _ => const <Badge>[],
+  };
+
+  Future<void> _drainBadgePopups(BuildContext context, BadgesState s) async {
+    if (_popupInFlight) {
+      return;
+    }
+    final fresh = _newly(s).where((b) => !_badgesShown.contains(b.code)).toList();
+    if (fresh.isEmpty) {
+      return;
+    }
+    _popupInFlight = true;
+    final cubit = context.read<BadgesCubit>();
+    final rootCubit = context.read<RootPageCubit>();
+    var jumpToProfile = false;
+    try {
+      for (final badge in fresh) {
+        if (!context.mounted) {
+          break;
+        }
+        final viewProfile = await BadgeEarnedPopup.show(context, cubit, [badge]);
+        _badgesShown.add(badge.code);
+        if (viewProfile) {
+          jumpToProfile = true;
+        }
+      }
+    } finally {
+      if (mounted) {
+        _popupInFlight = false;
+      }
+    }
+    if (jumpToProfile && mounted) {
+      // Pop any routes pushed on top of RootPage (e.g. the event details
+      // page) so the profile tab is actually visible after the switch.
+      final router = context.router;
+      while (router.canPop()) {
+        await router.maybePop();
+      }
+      if (mounted) {
+        rootCubit.navigateTo(RootPageState.profilePage);
+      }
+    }
+  }
 
   late final _tabs =
       [
@@ -66,7 +123,13 @@ class _RootPageState extends State<RootPage> {
           .toList();
 
   @override
-  Widget build(BuildContext context) => Stack(
+  Widget build(BuildContext context) => BlocListener<BadgesCubit, BadgesState>(
+    listenWhen: (p, c) {
+      final codes = _newly(c).map((b) => b.code).toSet();
+      return codes.difference(_badgesShown).isNotEmpty;
+    },
+    listener: _drainBadgePopups,
+    child: Stack(
     children: [
       Positioned.fill(
         child: BlocBuilder<RootPageCubit, RootPageState>(
@@ -100,5 +163,6 @@ class _RootPageState extends State<RootPage> {
         ),
       ),
     ],
+    ),
   );
 }


### PR DESCRIPTION
## Summary

Implements ticket **[badges] Mobile #10** from the org project board: a Badges section on the Profile screen with earned + locked states.

The section lives between Biography and Created events, matches the design in `iu-alumni-frontend/mockups/06-profile-v2-combined.png` and `11-badges-locked.png`, and works against a **mocked repository** because the public badges API ([badges #8]) hasn't shipped yet. The `BadgesRepository` interface mirrors the API contract from `BADGES_TICKETS.md` — swap `BadgesRepositoryMock` for a real impl when the backend lands.

### What's in

- **Models** (`lib/application/models/badge.dart`): plain Dart `Badge`, `EarnedBadge`, `LockedBadge`, `BadgesData`, `BadgeTier` enum. Not freezed — will convert when the real API arrives.
- **Repository** (`lib/application/repositories/badges/`): abstract interface + in-memory mock containing all 12 doable badges from the catalog (4 earned including Local Legend with city/year metadata, 8 locked at various progress).
- **State** (`lib/presentation/blocs/models/badges_state.dart`) + **cubit** (`lib/presentation/blocs/badges/badges_cubit.dart`): standard `LoadedState<BadgesData>` pattern matching the existing profile/events cubits.
- **UI** (`lib/presentation/pages/profile/widgets/badges_section.dart`): horizontal-scroll row, tiered gold/silver/bronze/special rings on earned badges, dashed gray ring + lock chip + green `(i)` info pill + mini progress bar on locked ones. Empty state copy: *"No badges yet — attend events to start unlocking them."*
- **Hover tooltip on the green `(i)` icon** (web/desktop) / long-press on mobile: shows badge name + description + progress. Help cursor on hover for discoverability.

### Wire-up

- `BadgesRepository` registered globally in `app.dart` (mocked).
- `BadgesCubit` provided **globally** in `app.dart` alongside `ProfileCubit`. *Originally scoped to the profile route's `wrappedRoute`, but the profile screen is reached via the tab router which bypasses that — Bloc threw a `ProviderNotFoundException`. Globalizing matches the existing pattern.*

### What's NOT in (deferred to follow-up tickets)

- **Tap-to-open details bottom-sheet** — ticket #11.
- **Celebratory popup for newly-earned badges** — ticket #12. The mock returns `newlyEarned: [Local Legend]` once for future testing.
- **Filter tabs (All / Earned / Locked)** — ticket #13.
- **Real backend** — depends on tickets #1–#8.

## Test plan

- [x] `flutter analyze` clean on all touched files
- [x] Verified live in browser at `http://localhost:5000` with the full-stack compose stack:
  - 4 earned tiles render with correct tier colors (Innopolis OG gold, Networker bronze, Host with the most silver, Local Legend gold)
  - 8 locked tiles render with dashed ring + lock + `(i)` + progress
  - Hover on `(i)` shows tooltip with name/description/progress
  - Empty state copy appears when mock returns empty lists
- [ ] Reviewer should pull, run `flutter run -d chrome --dart-define=API_BASE_URL=http://127.0.0.1:8080`, log in, check the Profile tab

## Design references

- Mockups (in `iu-alumni-frontend/mockups/`, not yet on GitHub):
  - `06-profile-v2-combined.png` — full profile with badges in context
  - `11-badges-locked.png` — earned + locked badge variants
- Doable-badges catalog + caveats: `Industrial Project/src/project/badges.md` (also not yet committed)

## Open questions for review

1. **Section placement** — currently between Biography and Created events. Move it earlier (right after name/avatar) for more prominence?
2. **Empty-state copy** — *"No badges yet — attend events to start unlocking them."* Better wording?
3. **Tier "SPECIAL" label** — used for Pioneer + Suggestion Box. Different label preferred? (e.g. "EVENT", "RARE")
4. **Description as tooltip vs. as bottom-sheet** — right now hover shows description in a tooltip; ticket #11 will also add a bottom-sheet on tap. Is that overlap OK or should one win?

---

**Closes** (auto-link on merge):
- Closes iu-alumni/iu-alumni-mobile#124 — Badges section on Profile screen

---

## Additionally: ticket #12 — celebratory popup

This branch now also implements the celebratory popup ([badges #134]) that appears the moment a badge is earned, from any tab. See commit f7ea5b6 for details.

- Closes iu-alumni/iu-alumni-mobile#134 — Mobile: celebratory popup