### PR TITLE
[codex] Fix mobile profile and map flows

### DIFF
--- a/lib/data/auth/auth_gateway_impl.dart
+++ b/lib/data/auth/auth_gateway_impl.dart
@@ -197,6 +197,11 @@ class AuthGatewayImpl implements AuthGateway {
       return Either.of(unit);
     } on DioException catch (e, st) {
       logger.e('Error requesting password reset', error: e, stackTrace: st);
+      final data = e.response?.data;
+      if (data is Map<String, dynamic>) {
+        final detail = data['detail'];
+        if (detail is String) return Left(detail);
+      }
       return Left(e.message ?? 'Unknown error');
     } catch (e) {
       return Left('$e');

--- a/lib/presentation/blocs/password_reset/password_reset_request_cubit.dart
+++ b/lib/presentation/blocs/password_reset/password_reset_request_cubit.dart
@@ -14,12 +14,15 @@ class PasswordResetRequestCubit extends Cubit<LoadedState<Unit>> {
   final PasswordResetRepository _repository;
 
   Future<void> requestReset(String email) async {
-    if (email.isEmpty) {
+    if (state is LoadedStateLoading<Unit>) return;
+
+    final normalizedEmail = email.trim();
+    if (normalizedEmail.isEmpty) {
       emit(const LoadedState.error('Please enter your email address'));
       return;
     }
     emit(const LoadedState.loading());
-    final result = await _repository.requestReset(email);
+    final result = await _repository.requestReset(normalizedEmail);
     emit(
       result.match(
         LoadedState.error,

--- a/lib/presentation/blocs/profile/profile_editing_cubit.dart
+++ b/lib/presentation/blocs/profile/profile_editing_cubit.dart
@@ -28,11 +28,24 @@ class ProfileEditingCubit extends Cubit<ProfileEditingState> {
   }
 
   void save() => state.profile.map((p) async {
+    final firstName = p.firstName.trim();
+    final lastName = p.lastName.trim();
+    if (firstName.isEmpty || lastName.isEmpty) {
+      emit(
+        state.copyWith(
+          saveState: const LoadedState.error('Please fill all required fields'),
+        ),
+      );
+      return;
+    }
+
+    final profile = p.copyWith(firstName: firstName, lastName: lastName);
     _reporter.reportSaveProfileChanges(AppLocation.profileEditingScreen);
     emit(state.copyWith(saveState: const LoadedState.loading()));
-    final success = await _repository.update(p);
+    final success = await _repository.update(profile);
     emit(
       state.copyWith(
+        profile: success ? Option.of(profile) : state.profile,
         saveState: success
             ? const LoadedState.data(unit)
             : const LoadedState.error('Could not save the modifications'),

--- a/lib/presentation/pages/city_data/city_data.dart
+++ b/lib/presentation/pages/city_data/city_data.dart
@@ -146,9 +146,8 @@ class _InCityButton extends StatelessWidget {
             overflow: TextOverflow.ellipsis,
           ),
         ),
-        if (profiles.isNotEmpty)
-          StackedRow(profiles: profiles)
-        else if (alumniCount > 0)
+        if (profiles.isNotEmpty) StackedRow(profiles: profiles),
+        if (alumniCount > 0)
           Text(
             '$alumniCount',
             style: AppTextStyles.caption.copyWith(color: AppColors.gray50),
@@ -237,4 +236,3 @@ class _InCitySheetState extends State<_InCitySheet> {
     ),
   );
 }
-

--- a/lib/presentation/pages/profile_editing/widgets/profile_editing_content.dart
+++ b/lib/presentation/pages/profile_editing/widgets/profile_editing_content.dart
@@ -76,6 +76,31 @@ class ProfileEditingContent {
           return ProfilePic(profile: p, edit: () => _updateAvatar(context));
         },
       ),
+      BlocBuilder<ProfileEditingCubit, ProfileEditingState>(
+        buildWhen: (pr, cu) =>
+            pr.profile.toNullable()?.avatar != cu.profile.toNullable()?.avatar,
+        builder: (context, ep) {
+          final p = ep.profile.toNullable() ?? profile;
+          if (p.avatar == null || p.avatar!.isEmpty) return const SizedBox();
+          return Padding(
+            padding: const EdgeInsets.only(top: 12),
+            child: Align(
+              child: AppButton(
+                buttonStyle: AppButtonStyle.gray,
+                onTap: () => context.read<ProfileEditingCubit>().update(
+                  (p) => p.copyWith(avatar: null),
+                ),
+                child: Text(
+                  'Remove photo',
+                  style: AppTextStyles.actionSB.copyWith(
+                    color: AppColors.darkGray,
+                  ),
+                ),
+              ),
+            ),
+          );
+        },
+      ),
       const SizedBox(height: 24),
       const _ErrorText(),
       TitledItem(


### PR DESCRIPTION
## Summary
- Prevent duplicate forgot-password submissions while a request is loading and show backend detail messages when available.
- Validate required profile names before save and support removing the profile avatar.
- Keep city map alumni counts aligned with backend counts after avatar loading.

Fixes #131

## Validation
- Not run: Flutter/Dart are not installed on PATH in this environment (`flutter analyze` unavailable).