### PR TITLE
[codex] Improve registration validation messages

### DIFF
--- a/lib/presentation/blocs/registration/registration_cubit.dart
+++ b/lib/presentation/blocs/registration/registration_cubit.dart
@@ -24,18 +24,62 @@ class RegistrationCubit extends Cubit<RegistrationState> {
       ? 'The password needs to contain at least 8 characters'
       : null;
 
-  Option<RegisterRequest> _verificationData({required bool manual}) =>
-      Option.Do(
-        (mb) => RegisterRequest(
-          firstName: mb(Option.fromNullable(state.firstName)),
-          lastName: mb(Option.fromNullable(state.lastName)),
-          gradYear: '${mb(Option.fromNullable(state.graduationYear))}',
-          email: mb(Option.fromNullable(state.email)),
-          telegram: state.telegram,
-          password: mb(Option.fromNullable(state.password)),
-          manualVerification: manual,
-        ),
-      );
+  String? _validateTelegram(String? telegram) {
+    if (telegram == null || telegram.isEmpty) return null;
+    return telegram.length < 3
+        ? 'Telegram alias must contain at least 3 characters'
+        : null;
+  }
+
+  String? _trimmed(String? value) {
+    final trimmed = value?.trim();
+    return trimmed == null || trimmed.isEmpty ? null : trimmed;
+  }
+
+  String _missingFieldsMessage(List<String> fields) {
+    if (fields.length == 1) {
+      return 'Please enter your ${fields.single}';
+    }
+
+    final allButLast = fields.take(fields.length - 1).join(', ');
+    return 'Please enter your $allButLast, and ${fields.last}';
+  }
+
+  Either<String, RegisterRequest> _verificationData({required bool manual}) {
+    final firstName = _trimmed(state.firstName);
+    final lastName = _trimmed(state.lastName);
+    final email = _trimmed(state.email);
+    final password = state.password;
+    final telegram = _trimmed(state.telegram);
+
+    final missingFields = [
+      if (firstName == null) 'first name',
+      if (lastName == null) 'last name',
+      if (email == null) 'university email',
+      if (state.graduationYear == null) 'graduation year',
+      if (password == null || password.isEmpty) 'password',
+    ];
+
+    if (missingFields.isNotEmpty) {
+      return Left(_missingFieldsMessage(missingFields));
+    }
+
+    if (_validateTelegram(telegram) case final e?) {
+      return Left(e);
+    }
+
+    return Right(
+      RegisterRequest(
+        firstName: firstName!,
+        lastName: lastName!,
+        gradYear: '${state.graduationYear}',
+        email: email!,
+        telegram: telegram,
+        password: password!,
+        manualVerification: manual,
+      ),
+    );
+  }
 
   void toInitial() =>
       emit(const RegistrationState(verification: LoadedState.init()));
@@ -60,9 +104,6 @@ class RegistrationCubit extends Cubit<RegistrationState> {
 
   Either<String, RegisterRequest> verificationRequest(bool manual) =>
       _verificationData(manual: manual)
-          .toEither(
-            () => 'Please, specify all fields to complete the verification',
-          )
           .flatMap<RegisterRequest>(
             (r) => switch (_validateEmail(r.email)) {
               final e? => Left(e),

--- a/test/unit/blocs/registration_cubit_test.dart
+++ b/test/unit/blocs/registration_cubit_test.dart
@@ -1,0 +1,107 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fpdart/fpdart.dart';
+import 'package:ui_alumni_mobile/application/models/register_request.dart';
+import 'package:ui_alumni_mobile/application/repositories/auth/auth_repository.dart';
+import 'package:ui_alumni_mobile/application/repositories/reporter/reporter_mock.dart';
+import 'package:ui_alumni_mobile/presentation/blocs/registration/registration_cubit.dart';
+
+class _FakeAuthRepository implements AuthRepository {
+  @override
+  Future<Either<String, Unit>> authorize(String login, String password) async =>
+      const Right(unit);
+
+  @override
+  void cleanEmail() {}
+
+  @override
+  Future<Either<String, Either<Unit, Unit>>> register(
+    RegisterRequest request,
+  ) async =>
+      const Right(Right(unit));
+
+  @override
+  Future<Either<String?, Unit>> sendCode() async => const Right(unit);
+
+  @override
+  void setEmail(String email) {}
+
+  @override
+  Future<Either<String?, Unit>> verifyCode(String code) async =>
+      const Right(unit);
+}
+
+String _leftMessage(Either<String, RegisterRequest> result) =>
+    result.fold((error) => error, (_) => fail('Expected validation error'));
+
+RegisterRequest _rightRequest(Either<String, RegisterRequest> result) =>
+    result.fold((error) => fail(error), (request) => request);
+
+void main() {
+  late _FakeAuthRepository authRepository;
+  late RegistrationCubit cubit;
+
+  setUp(() {
+    authRepository = _FakeAuthRepository();
+    cubit = RegistrationCubit(authRepository, ReporterMock());
+  });
+
+  tearDown(() => cubit.close());
+
+  void fillRequiredFields() {
+    cubit
+      ..setFirstName('Ada')
+      ..setLastName('Lovelace')
+      ..setEmail('ada@innopolis.university')
+      ..setGradYear(2024)
+      ..setPassword('password123');
+  }
+
+  group('RegistrationCubit validation', () {
+    test('returns clear missing-field message for blank required fields', () {
+      cubit
+        ..setFirstName('   ')
+        ..setLastName('')
+        ..setEmail('  ')
+        ..setPassword('');
+
+      final result = cubit.verificationRequest(false);
+
+      expect(result.isLeft(), isTrue);
+      expect(
+        _leftMessage(result),
+        'Please enter your first name, last name, university email, '
+        'graduation year, and password',
+      );
+    });
+
+    test('trims required fields and omits blank optional Telegram alias', () {
+      cubit
+        ..setFirstName('  Ada  ')
+        ..setLastName('  Lovelace  ')
+        ..setEmail('  ada@innopolis.university  ')
+        ..setGradYear(2024)
+        ..setTelegram('   ')
+        ..setPassword('password123');
+
+      final request = _rightRequest(cubit.verificationRequest(false));
+
+      expect(request?.firstName, 'Ada');
+      expect(request?.lastName, 'Lovelace');
+      expect(request?.email, 'ada@innopolis.university');
+      expect(request?.telegram, isNull);
+    });
+
+    test('returns clear message for too-short Telegram alias', () {
+      fillRequiredFields();
+      cubit.setTelegram('@a');
+
+      final result = cubit.verificationRequest(false);
+
+      expect(result.isLeft(), isTrue);
+      expect(
+        _leftMessage(result),
+        'Telegram alias must contain at least 3 characters',
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Validate required registration fields before creating the request so blank values do not fall through to backend schema errors.
- Trim first name, last name, and email before submission.
- Treat blank Telegram alias as omitted, while showing a clear message for a too-short alias.
- Add focused RegistrationCubit tests for missing fields, blank optional Telegram alias, and short Telegram alias.

Closes #132

## Validation
- `git diff --check`
- Not run: `dart` and `flutter` are not installed on PATH in this environment, so formatting/analyzer/unit tests could not be executed locally.