### PR TITLE
[codex] Fix mobile auth email errors

### DIFF
--- a/lib/presentation/blocs/password_reset/password_reset_request_cubit.dart
+++ b/lib/presentation/blocs/password_reset/password_reset_request_cubit.dart
@@ -3,6 +3,7 @@ import 'package:fpdart/fpdart.dart';
 
 import '../../../application/repositories/auth/password_reset_repository.dart';
 import '../../common/models/loaded_state.dart';
+import '../../common/utils/university_email.dart';
 
 /// Manages the "Forgot password?" request step.
 /// Emits [LoadedState.data] when the email was submitted successfully —
@@ -19,6 +20,11 @@ class PasswordResetRequestCubit extends Cubit<LoadedState<Unit>> {
     final normalizedEmail = email.trim();
     if (normalizedEmail.isEmpty) {
       emit(const LoadedState.error('Please enter your email address'));
+      return;
+    }
+    final emailError = validateUniversityEmail(normalizedEmail);
+    if (emailError != null) {
+      emit(LoadedState.error(emailError));
       return;
     }
     emit(const LoadedState.loading());

--- a/lib/presentation/common/utils/university_email.dart
+++ b/lib/presentation/common/utils/university_email.dart
@@ -1,0 +1,7 @@
+const String universityEmailDomainError =
+    'The email must contain either "innopolis.university" or "innopolis.ru"';
+
+String? validateUniversityEmail(String email) =>
+    (email.contains('@innopolis.university') || email.contains('@innopolis.ru'))
+    ? null
+    : universityEmailDomainError;

--- a/lib/presentation/pages/auth/subpages/restored_verification_sub_page.dart
+++ b/lib/presentation/pages/auth/subpages/restored_verification_sub_page.dart
@@ -7,6 +7,7 @@ import 'package:ui_alumni_mobile/presentation/common/widgets/app_button.dart';
 import 'package:ui_alumni_mobile/presentation/common/widgets/app_loader.dart';
 import 'package:ui_alumni_mobile/presentation/common/widgets/app_scaffold.dart';
 import 'package:ui_alumni_mobile/presentation/common/widgets/app_text_field.dart';
+import 'package:ui_alumni_mobile/presentation/common/utils/university_email.dart';
 
 import '../../../../application/repositories/auth/auth_repository.dart';
 
@@ -27,13 +28,28 @@ class _RestoredVerificationSubPageState
   bool _success = false;
 
   Future<void> _resend() async {
-    if (_email.isEmpty) return;
+    final email = _email.trim();
+    if (email.isEmpty) {
+      setState(() {
+        _message = 'Please enter your email';
+        _success = false;
+      });
+      return;
+    }
+    final emailError = validateUniversityEmail(email);
+    if (emailError != null) {
+      setState(() {
+        _message = emailError;
+        _success = false;
+      });
+      return;
+    }
     setState(() {
       _loading = true;
       _message = null;
     });
     final repo = context.read<AuthRepository>();
-    repo.setEmail(_email);
+    repo.setEmail(email);
     final result = await repo.sendCode();
     if (!mounted) return;
     setState(() {

--- a/test/unit/blocs/password_reset_request_cubit_test.dart
+++ b/test/unit/blocs/password_reset_request_cubit_test.dart
@@ -1,0 +1,52 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fpdart/fpdart.dart';
+import 'package:ui_alumni_mobile/application/repositories/auth/password_reset_repository.dart';
+import 'package:ui_alumni_mobile/presentation/blocs/password_reset/password_reset_request_cubit.dart';
+import 'package:ui_alumni_mobile/presentation/common/models/loaded_state.dart';
+import 'package:ui_alumni_mobile/presentation/common/utils/university_email.dart';
+
+class _FakePasswordResetRepository implements PasswordResetRepository {
+  String? requestedEmail;
+
+  @override
+  Future<Either<String, Unit>> requestReset(String email) async {
+    requestedEmail = email;
+    return const Right(unit);
+  }
+
+  @override
+  Future<Either<String, Unit>> confirmReset({
+    required String token,
+    required String newPassword,
+  }) async =>
+      const Right(unit);
+}
+
+void main() {
+  late _FakePasswordResetRepository repository;
+  late PasswordResetRequestCubit cubit;
+
+  setUp(() {
+    repository = _FakePasswordResetRepository();
+    cubit = PasswordResetRequestCubit(repository);
+  });
+
+  tearDown(() => cubit.close());
+
+  test('rejects non-Innopolis email before requesting reset link', () async {
+    await cubit.requestReset('person@example.com');
+
+    expect(
+      cubit.state,
+      const LoadedState<Unit>.error(universityEmailDomainError),
+    );
+    expect(repository.requestedEmail, isNull);
+  });
+
+  test('trims and submits Innopolis email', () async {
+    await cubit.requestReset('  person@innopolis.university  ');
+
+    expect(cubit.state, const LoadedState<Unit>.data(unit));
+    expect(repository.requestedEmail, 'person@innopolis.university');
+  });
+}


### PR DESCRIPTION
## Summary
- validate Innopolis email domains before resending verification links
- validate password reset request emails before calling the backend
- add a focused cubit test for password reset email validation

## Why
Wrong-domain emails currently progress into auth flows and leave users with confusing feedback. This keeps the form visible and shows the same domain error used by sign-in and OTP flows.

Fixes #129
Fixes #130
Related #103: current main already includes the city-user loading fix from #139/#120, so this PR intentionally leaves that path unchanged.

## Validation
- git diff --check
- Not run locally: flutter/dart are not installed on this machine; GitHub Actions will run the mobile validation.