### PR TITLE
Add notifications bell + panel on the events dashboard

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -26,6 +26,8 @@ import 'application/repositories/events/events_repository.dart';
 import 'application/repositories/events/events_repository_impl.dart';
 import 'application/repositories/map/map_repository.dart';
 import 'application/repositories/map/map_repository_impl.dart';
+import 'application/repositories/notifications/notifications_repository.dart';
+import 'application/repositories/notifications/notifications_repository_impl.dart';
 import 'application/repositories/reporter/reporter.dart';
 import 'application/repositories/reporter/reporter_appmetrica.dart';
 import 'application/repositories/users/users_repository.dart';
@@ -35,6 +37,8 @@ import 'data/auth/auth_gateway_impl.dart';
 import 'data/common/dio_options_manager.dart';
 import 'data/events/events_gateway.dart';
 import 'data/events/events_gateway_impl.dart';
+import 'data/notifications/notifications_gateway.dart';
+import 'data/notifications/notifications_gateway_impl.dart';
 import 'data/profile/profile_gateway.dart';
 import 'data/profile/profile_gateway_impl.dart';
 import 'data/config/api_config.dart';
@@ -46,6 +50,7 @@ import 'data/users/users_gateway.dart';
 import 'data/users/users_gateway_impl.dart';
 import 'presentation/blocs/badges/badges_cubit.dart';
 import 'presentation/blocs/events_list/events_list_cubit.dart';
+import 'presentation/blocs/notifications/notifications_cubit.dart';
 import 'presentation/blocs/profile/profile_cubit.dart';
 import 'presentation/common/constants/app_colors.dart';
 import 'presentation/router/always_root_route.dart';
@@ -126,6 +131,12 @@ class App extends StatelessWidget {
           context.read<DioOptionsManager>(),
         ),
       ),
+      RepositoryProvider<NotificationsGateway>(
+        create: (context) => NotificationsGatewayImpl(
+          context.read<Dio>(),
+          context.read<DioOptionsManager>(),
+        ),
+      ),
       // --- REPOSITORIES ---
       RepositoryProvider<AuthRepository>(
         create: (context) => AuthRepositoryImpl(context.read<AuthGateway>()),
@@ -181,6 +192,11 @@ class App extends StatelessWidget {
           context.read<DioOptionsManager>(),
         ),
       ),
+      RepositoryProvider<NotificationsRepository>(
+        create: (context) => NotificationsRepositoryImpl(
+          context.read<NotificationsGateway>(),
+        ),
+      ),
       // --- BLOCs ---
       BlocProvider(
         create: (context) => EventsListCubit(context.read<EventsRepository>()),
@@ -193,6 +209,10 @@ class App extends StatelessWidget {
       ),
       BlocProvider(
         create: (ctx) => BadgesCubit(ctx.read<BadgesRepository>())..loadMine(),
+      ),
+      BlocProvider(
+        create: (context) =>
+            NotificationsCubit(context.read<NotificationsRepository>()),
       ),
     ],
     child: Builder(

--- a/lib/application/mappers/notification_mapper.dart
+++ b/lib/application/mappers/notification_mapper.dart
@@ -1,0 +1,14 @@
+import '../../data/models/notification_data_model.dart';
+import '../models/notification.dart';
+
+abstract class NotificationMapper {
+  static NotificationModel fromData(NotificationDataModel data) =>
+      NotificationModel(
+        id: data.id,
+        eventId: data.eventId,
+        title: data.title,
+        location: data.location,
+        datetime: data.datetime,
+        read: data.read,
+      );
+}

--- a/lib/application/models/notification.dart
+++ b/lib/application/models/notification.dart
@@ -1,0 +1,15 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'notification.freezed.dart';
+
+@freezed
+class NotificationModel with _$NotificationModel {
+  const factory NotificationModel({
+    required String id,
+    required String eventId,
+    required String title,
+    required String location,
+    required DateTime datetime,
+    required bool read,
+  }) = _NotificationModel;
+}

--- a/lib/application/models/notification.freezed.dart
+++ b/lib/application/models/notification.freezed.dart
@@ -1,0 +1,278 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'notification.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+  'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models',
+);
+
+/// @nodoc
+mixin _$NotificationModel {
+  String get id => throw _privateConstructorUsedError;
+  String get eventId => throw _privateConstructorUsedError;
+  String get title => throw _privateConstructorUsedError;
+  String get location => throw _privateConstructorUsedError;
+  DateTime get datetime => throw _privateConstructorUsedError;
+  bool get read => throw _privateConstructorUsedError;
+
+  /// Create a copy of NotificationModel
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  $NotificationModelCopyWith<NotificationModel> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $NotificationModelCopyWith<$Res> {
+  factory $NotificationModelCopyWith(
+    NotificationModel value,
+    $Res Function(NotificationModel) then,
+  ) = _$NotificationModelCopyWithImpl<$Res, NotificationModel>;
+  @useResult
+  $Res call({
+    String id,
+    String eventId,
+    String title,
+    String location,
+    DateTime datetime,
+    bool read,
+  });
+}
+
+/// @nodoc
+class _$NotificationModelCopyWithImpl<$Res, $Val extends NotificationModel>
+    implements $NotificationModelCopyWith<$Res> {
+  _$NotificationModelCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of NotificationModel
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? id = null,
+    Object? eventId = null,
+    Object? title = null,
+    Object? location = null,
+    Object? datetime = null,
+    Object? read = null,
+  }) {
+    return _then(
+      _value.copyWith(
+            id:
+                null == id
+                    ? _value.id
+                    : id // ignore: cast_nullable_to_non_nullable
+                        as String,
+            eventId:
+                null == eventId
+                    ? _value.eventId
+                    : eventId // ignore: cast_nullable_to_non_nullable
+                        as String,
+            title:
+                null == title
+                    ? _value.title
+                    : title // ignore: cast_nullable_to_non_nullable
+                        as String,
+            location:
+                null == location
+                    ? _value.location
+                    : location // ignore: cast_nullable_to_non_nullable
+                        as String,
+            datetime:
+                null == datetime
+                    ? _value.datetime
+                    : datetime // ignore: cast_nullable_to_non_nullable
+                        as DateTime,
+            read:
+                null == read
+                    ? _value.read
+                    : read // ignore: cast_nullable_to_non_nullable
+                        as bool,
+          )
+          as $Val,
+    );
+  }
+}
+
+/// @nodoc
+abstract class _$$NotificationModelImplCopyWith<$Res>
+    implements $NotificationModelCopyWith<$Res> {
+  factory _$$NotificationModelImplCopyWith(
+    _$NotificationModelImpl value,
+    $Res Function(_$NotificationModelImpl) then,
+  ) = __$$NotificationModelImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({
+    String id,
+    String eventId,
+    String title,
+    String location,
+    DateTime datetime,
+    bool read,
+  });
+}
+
+/// @nodoc
+class __$$NotificationModelImplCopyWithImpl<$Res>
+    extends _$NotificationModelCopyWithImpl<$Res, _$NotificationModelImpl>
+    implements _$$NotificationModelImplCopyWith<$Res> {
+  __$$NotificationModelImplCopyWithImpl(
+    _$NotificationModelImpl _value,
+    $Res Function(_$NotificationModelImpl) _then,
+  ) : super(_value, _then);
+
+  /// Create a copy of NotificationModel
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? id = null,
+    Object? eventId = null,
+    Object? title = null,
+    Object? location = null,
+    Object? datetime = null,
+    Object? read = null,
+  }) {
+    return _then(
+      _$NotificationModelImpl(
+        id:
+            null == id
+                ? _value.id
+                : id // ignore: cast_nullable_to_non_nullable
+                    as String,
+        eventId:
+            null == eventId
+                ? _value.eventId
+                : eventId // ignore: cast_nullable_to_non_nullable
+                    as String,
+        title:
+            null == title
+                ? _value.title
+                : title // ignore: cast_nullable_to_non_nullable
+                    as String,
+        location:
+            null == location
+                ? _value.location
+                : location // ignore: cast_nullable_to_non_nullable
+                    as String,
+        datetime:
+            null == datetime
+                ? _value.datetime
+                : datetime // ignore: cast_nullable_to_non_nullable
+                    as DateTime,
+        read:
+            null == read
+                ? _value.read
+                : read // ignore: cast_nullable_to_non_nullable
+                    as bool,
+      ),
+    );
+  }
+}
+
+/// @nodoc
+
+class _$NotificationModelImpl implements _NotificationModel {
+  const _$NotificationModelImpl({
+    required this.id,
+    required this.eventId,
+    required this.title,
+    required this.location,
+    required this.datetime,
+    required this.read,
+  });
+
+  @override
+  final String id;
+  @override
+  final String eventId;
+  @override
+  final String title;
+  @override
+  final String location;
+  @override
+  final DateTime datetime;
+  @override
+  final bool read;
+
+  @override
+  String toString() {
+    return 'NotificationModel(id: $id, eventId: $eventId, title: $title, location: $location, datetime: $datetime, read: $read)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$NotificationModelImpl &&
+            (identical(other.id, id) || other.id == id) &&
+            (identical(other.eventId, eventId) || other.eventId == eventId) &&
+            (identical(other.title, title) || other.title == title) &&
+            (identical(other.location, location) ||
+                other.location == location) &&
+            (identical(other.datetime, datetime) ||
+                other.datetime == datetime) &&
+            (identical(other.read, read) || other.read == read));
+  }
+
+  @override
+  int get hashCode =>
+      Object.hash(runtimeType, id, eventId, title, location, datetime, read);
+
+  /// Create a copy of NotificationModel
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$NotificationModelImplCopyWith<_$NotificationModelImpl> get copyWith =>
+      __$$NotificationModelImplCopyWithImpl<_$NotificationModelImpl>(
+        this,
+        _$identity,
+      );
+}
+
+abstract class _NotificationModel implements NotificationModel {
+  const factory _NotificationModel({
+    required final String id,
+    required final String eventId,
+    required final String title,
+    required final String location,
+    required final DateTime datetime,
+    required final bool read,
+  }) = _$NotificationModelImpl;
+
+  @override
+  String get id;
+  @override
+  String get eventId;
+  @override
+  String get title;
+  @override
+  String get location;
+  @override
+  DateTime get datetime;
+  @override
+  bool get read;
+
+  /// Create a copy of NotificationModel
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$NotificationModelImplCopyWith<_$NotificationModelImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/application/repositories/events/events_repository.dart
+++ b/lib/application/repositories/events/events_repository.dart
@@ -21,7 +21,7 @@ abstract interface class EventsRepository {
 
   Future<void> deleteEvent(String eventId);
 
-  Future<Option<String>> save();
+  Future<Either<String, String>> save();
 
   Future<Option<EventModel>> participate(String eventId);
 

--- a/lib/application/repositories/events/events_repository_impl.dart
+++ b/lib/application/repositories/events/events_repository_impl.dart
@@ -109,26 +109,24 @@ class EventsRepositoryImpl implements EventsRepository {
     _modifiedEvent = event;
   }
 
-  Future<Option<String>> _mutateAndSave(EventModel event) async {
+  Future<Either<String, String>> _mutateAndSave(EventModel event) async {
     final eventRequest = EventMapper.eventRequestFromModel(event);
     // Has event already been in the created ever (otherwise it is new)
     if (_cache!.containsKey(event.eventId)) {
-      final success = await _gateway.updateEvent(event.eventId, eventRequest);
-      if (success) {
+      final result = await _gateway.updateEvent(event.eventId, eventRequest);
+      return result.match(Left.new, (_) {
         // Update the event in the cache on success
         _cache![event.eventId] = event;
         // When modified, the event ID stays the same
-        return Option.of(event.eventId);
-      }
-      // The event modification was not successful, none for the error state
-      return const None();
+        return Right(event.eventId);
+      });
     } else {
       // Event not found in the cache, so it is a new event
-      final newId = await _gateway.addEvent(eventRequest);
+      final result = await _gateway.addEvent(eventRequest);
       // Load personal profile to add the ID of the creator
       final myProfile = await _usersRepository.loadMe();
       // Update the event ID by the one server responded with
-      newId.map((eid) {
+      return result.match(Left.new, (eid) {
         _cache![eid] = event.copyWith(
           eventId: eid,
           participantsIds: [
@@ -136,17 +134,17 @@ class EventsRepositoryImpl implements EventsRepository {
           ].toISet(),
         );
         _owned!.add(eid);
+        return Right(eid);
       });
-      return newId;
     }
   }
 
   @override
-  Future<Option<String>> save() async {
+  Future<Either<String, String>> save() async {
     final event = _modifiedEvent;
     if (event == null) {
       // Nothing modified, so nothing to save
-      return const None();
+      return const Left('Nothing to save.');
     }
     _modifiedEvent = null;
     return _mutateAndSave(_fixEvent(event));

--- a/lib/application/repositories/notifications/notifications_repository.dart
+++ b/lib/application/repositories/notifications/notifications_repository.dart
@@ -1,0 +1,9 @@
+import '../../models/notification.dart';
+
+abstract interface class NotificationsRepository {
+  /// Fetches every page of notifications. Note: per the backend, this marks
+  /// all currently-unread notifications as read as a side effect.
+  Future<Iterable<NotificationModel>> getNotifications();
+
+  Future<int> getUnreadCount();
+}

--- a/lib/application/repositories/notifications/notifications_repository_impl.dart
+++ b/lib/application/repositories/notifications/notifications_repository_impl.dart
@@ -1,0 +1,26 @@
+import '../../../data/notifications/notifications_gateway.dart';
+import '../../mappers/notification_mapper.dart';
+import '../../models/notification.dart';
+import 'notifications_repository.dart';
+
+class NotificationsRepositoryImpl implements NotificationsRepository {
+  NotificationsRepositoryImpl(this._gateway);
+
+  final NotificationsGateway _gateway;
+
+  @override
+  Future<Iterable<NotificationModel>> getNotifications() async {
+    final items = <dynamic>[];
+    String? cursor;
+    do {
+      final page = await _gateway.loadNotifications(cursor: cursor, limit: 100);
+      items.addAll(page.items);
+      cursor = page.nextCursor;
+    } while (cursor != null);
+
+    return items.map((d) => NotificationMapper.fromData(d));
+  }
+
+  @override
+  Future<int> getUnreadCount() => _gateway.loadUnreadCount();
+}

--- a/lib/data/events/events_gateway.dart
+++ b/lib/data/events/events_gateway.dart
@@ -7,8 +7,8 @@ import '../models/event_request_data_model.dart';
 abstract interface class EventsGateway {
   Future<PaginatedResult<EventDataModel>> loadEvents({String? cursor, int limit});
   Future<PaginatedResult<EventDataModel>> loadPendingEvents({String? cursor, int limit});
-  Future<Option<String>> addEvent(EventRequestDataModel event);
-  Future<bool> updateEvent(String eventId, EventRequestDataModel event);
+  Future<Either<String, String>> addEvent(EventRequestDataModel event);
+  Future<Either<String, Unit>> updateEvent(String eventId, EventRequestDataModel event);
   Future<bool> deleteEvent(String eventId);
   Future<bool> participate(String eventId, String userId);
   Future<bool> leave(String eventId, String userId);

--- a/lib/data/events/events_gateway_impl.dart
+++ b/lib/data/events/events_gateway_impl.dart
@@ -17,7 +17,7 @@ class EventsGatewayImpl implements EventsGateway {
   final DioOptionsManager _optionsManager;
 
   @override
-  Future<Option<String>> addEvent(EventRequestDataModel event) async {
+  Future<Either<String, String>> addEvent(EventRequestDataModel event) async {
     final result = await TaskEither.tryCatch(() async {
       final data = jsonEncode(event.toJson());
       final response = await _dio.post(
@@ -27,8 +27,8 @@ class EventsGatewayImpl implements EventsGateway {
       );
       final json = response.data as Map<String, dynamic>;
       return json['id'] as String;
-    }, (e, _) => '$e').run();
-    return result.toOption();
+    }, (e, _) => _extractErrorMessage(e)).run();
+    return result;
   }
 
   @override
@@ -92,7 +92,10 @@ class EventsGatewayImpl implements EventsGateway {
   }
 
   @override
-  Future<bool> updateEvent(String eventId, EventRequestDataModel event) async {
+  Future<Either<String, Unit>> updateEvent(
+    String eventId,
+    EventRequestDataModel event,
+  ) async {
     final result = await TaskEither.tryCatch(() async {
       final requestModel = event.toJson();
       await _dio.put(
@@ -100,9 +103,62 @@ class EventsGatewayImpl implements EventsGateway {
         options: _optionsManager.opts(),
         data: jsonEncode(requestModel),
       );
-    }, (e, _) => '$e').run();
-    return result.isRight();
+      return unit;
+    }, (e, _) => _extractErrorMessage(e)).run();
+    return result;
   }
+
+  /// Turns a Dio/API failure into a message a user can act on.
+  ///
+  /// Mirrors the FastAPI error shapes: `{"detail": "..."}` for plain errors
+  /// and `{"detail": [{"loc": [...], "msg": "..."}]}` for validation errors.
+  String _extractErrorMessage(Object error) {
+    if (error is DioException) {
+      final data = error.response?.data;
+      if (data is Map<String, dynamic>) {
+        final detail = data['detail'];
+        if (detail is String) {
+          return detail;
+        }
+        if (detail is List) {
+          final messages = detail
+              .whereType<Map<String, dynamic>>()
+              .map((d) {
+                final loc = d['loc'];
+                final field = loc is List && loc.isNotEmpty
+                    ? loc.last.toString()
+                    : null;
+                final msg = (d['msg'] as String?)?.replaceFirst(
+                  'Value error, ',
+                  '',
+                );
+                if (msg == null) {
+                  return null;
+                }
+                return field != null ? '${_titleCase(field)}: $msg' : msg;
+              })
+              .nonNulls
+              .toList();
+          if (messages.isNotEmpty) {
+            return messages.join('\n');
+          }
+        }
+      }
+      return switch (error.type) {
+        DioExceptionType.connectionTimeout ||
+        DioExceptionType.sendTimeout ||
+        DioExceptionType.receiveTimeout =>
+          'The request timed out. Please check your connection and try again.',
+        DioExceptionType.connectionError =>
+          'Could not reach the server. Please check your connection.',
+        _ => 'Something went wrong${error.response?.statusCode != null ? ' (${error.response!.statusCode})' : ''}.',
+      };
+    }
+    return '$error';
+  }
+
+  String _titleCase(String field) =>
+      field.isEmpty ? field : '${field[0].toUpperCase()}${field.substring(1)}';
 
   @override
   Future<bool> participate(String eventId, String userId) async {

--- a/lib/data/models/notification_data_model.dart
+++ b/lib/data/models/notification_data_model.dart
@@ -1,0 +1,19 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'notification_data_model.freezed.dart';
+part 'notification_data_model.g.dart';
+
+@freezed
+class NotificationDataModel with _$NotificationDataModel {
+  factory NotificationDataModel({
+    required String id,
+    @JsonKey(name: 'event_id') required String eventId,
+    required String title,
+    required String location,
+    required DateTime datetime,
+    required bool read,
+  }) = _NotificationDataModel;
+
+  factory NotificationDataModel.fromJson(Map<String, dynamic> json) =>
+      _$NotificationDataModelFromJson(json);
+}

--- a/lib/data/models/notification_data_model.freezed.dart
+++ b/lib/data/models/notification_data_model.freezed.dart
@@ -1,0 +1,307 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'notification_data_model.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+  'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models',
+);
+
+NotificationDataModel _$NotificationDataModelFromJson(
+  Map<String, dynamic> json,
+) {
+  return _NotificationDataModel.fromJson(json);
+}
+
+/// @nodoc
+mixin _$NotificationDataModel {
+  String get id => throw _privateConstructorUsedError;
+  @JsonKey(name: 'event_id')
+  String get eventId => throw _privateConstructorUsedError;
+  String get title => throw _privateConstructorUsedError;
+  String get location => throw _privateConstructorUsedError;
+  DateTime get datetime => throw _privateConstructorUsedError;
+  bool get read => throw _privateConstructorUsedError;
+
+  /// Serializes this NotificationDataModel to a JSON map.
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+
+  /// Create a copy of NotificationDataModel
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  $NotificationDataModelCopyWith<NotificationDataModel> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $NotificationDataModelCopyWith<$Res> {
+  factory $NotificationDataModelCopyWith(
+    NotificationDataModel value,
+    $Res Function(NotificationDataModel) then,
+  ) = _$NotificationDataModelCopyWithImpl<$Res, NotificationDataModel>;
+  @useResult
+  $Res call({
+    String id,
+    @JsonKey(name: 'event_id') String eventId,
+    String title,
+    String location,
+    DateTime datetime,
+    bool read,
+  });
+}
+
+/// @nodoc
+class _$NotificationDataModelCopyWithImpl<
+  $Res,
+  $Val extends NotificationDataModel
+>
+    implements $NotificationDataModelCopyWith<$Res> {
+  _$NotificationDataModelCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of NotificationDataModel
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? id = null,
+    Object? eventId = null,
+    Object? title = null,
+    Object? location = null,
+    Object? datetime = null,
+    Object? read = null,
+  }) {
+    return _then(
+      _value.copyWith(
+            id:
+                null == id
+                    ? _value.id
+                    : id // ignore: cast_nullable_to_non_nullable
+                        as String,
+            eventId:
+                null == eventId
+                    ? _value.eventId
+                    : eventId // ignore: cast_nullable_to_non_nullable
+                        as String,
+            title:
+                null == title
+                    ? _value.title
+                    : title // ignore: cast_nullable_to_non_nullable
+                        as String,
+            location:
+                null == location
+                    ? _value.location
+                    : location // ignore: cast_nullable_to_non_nullable
+                        as String,
+            datetime:
+                null == datetime
+                    ? _value.datetime
+                    : datetime // ignore: cast_nullable_to_non_nullable
+                        as DateTime,
+            read:
+                null == read
+                    ? _value.read
+                    : read // ignore: cast_nullable_to_non_nullable
+                        as bool,
+          )
+          as $Val,
+    );
+  }
+}
+
+/// @nodoc
+abstract class _$$NotificationDataModelImplCopyWith<$Res>
+    implements $NotificationDataModelCopyWith<$Res> {
+  factory _$$NotificationDataModelImplCopyWith(
+    _$NotificationDataModelImpl value,
+    $Res Function(_$NotificationDataModelImpl) then,
+  ) = __$$NotificationDataModelImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({
+    String id,
+    @JsonKey(name: 'event_id') String eventId,
+    String title,
+    String location,
+    DateTime datetime,
+    bool read,
+  });
+}
+
+/// @nodoc
+class __$$NotificationDataModelImplCopyWithImpl<$Res>
+    extends
+        _$NotificationDataModelCopyWithImpl<$Res, _$NotificationDataModelImpl>
+    implements _$$NotificationDataModelImplCopyWith<$Res> {
+  __$$NotificationDataModelImplCopyWithImpl(
+    _$NotificationDataModelImpl _value,
+    $Res Function(_$NotificationDataModelImpl) _then,
+  ) : super(_value, _then);
+
+  /// Create a copy of NotificationDataModel
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? id = null,
+    Object? eventId = null,
+    Object? title = null,
+    Object? location = null,
+    Object? datetime = null,
+    Object? read = null,
+  }) {
+    return _then(
+      _$NotificationDataModelImpl(
+        id:
+            null == id
+                ? _value.id
+                : id // ignore: cast_nullable_to_non_nullable
+                    as String,
+        eventId:
+            null == eventId
+                ? _value.eventId
+                : eventId // ignore: cast_nullable_to_non_nullable
+                    as String,
+        title:
+            null == title
+                ? _value.title
+                : title // ignore: cast_nullable_to_non_nullable
+                    as String,
+        location:
+            null == location
+                ? _value.location
+                : location // ignore: cast_nullable_to_non_nullable
+                    as String,
+        datetime:
+            null == datetime
+                ? _value.datetime
+                : datetime // ignore: cast_nullable_to_non_nullable
+                    as DateTime,
+        read:
+            null == read
+                ? _value.read
+                : read // ignore: cast_nullable_to_non_nullable
+                    as bool,
+      ),
+    );
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$NotificationDataModelImpl implements _NotificationDataModel {
+  _$NotificationDataModelImpl({
+    required this.id,
+    @JsonKey(name: 'event_id') required this.eventId,
+    required this.title,
+    required this.location,
+    required this.datetime,
+    required this.read,
+  });
+
+  factory _$NotificationDataModelImpl.fromJson(Map<String, dynamic> json) =>
+      _$$NotificationDataModelImplFromJson(json);
+
+  @override
+  final String id;
+  @override
+  @JsonKey(name: 'event_id')
+  final String eventId;
+  @override
+  final String title;
+  @override
+  final String location;
+  @override
+  final DateTime datetime;
+  @override
+  final bool read;
+
+  @override
+  String toString() {
+    return 'NotificationDataModel(id: $id, eventId: $eventId, title: $title, location: $location, datetime: $datetime, read: $read)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$NotificationDataModelImpl &&
+            (identical(other.id, id) || other.id == id) &&
+            (identical(other.eventId, eventId) || other.eventId == eventId) &&
+            (identical(other.title, title) || other.title == title) &&
+            (identical(other.location, location) ||
+                other.location == location) &&
+            (identical(other.datetime, datetime) ||
+                other.datetime == datetime) &&
+            (identical(other.read, read) || other.read == read));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode =>
+      Object.hash(runtimeType, id, eventId, title, location, datetime, read);
+
+  /// Create a copy of NotificationDataModel
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$NotificationDataModelImplCopyWith<_$NotificationDataModelImpl>
+  get copyWith =>
+      __$$NotificationDataModelImplCopyWithImpl<_$NotificationDataModelImpl>(
+        this,
+        _$identity,
+      );
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$NotificationDataModelImplToJson(this);
+  }
+}
+
+abstract class _NotificationDataModel implements NotificationDataModel {
+  factory _NotificationDataModel({
+    required final String id,
+    @JsonKey(name: 'event_id') required final String eventId,
+    required final String title,
+    required final String location,
+    required final DateTime datetime,
+    required final bool read,
+  }) = _$NotificationDataModelImpl;
+
+  factory _NotificationDataModel.fromJson(Map<String, dynamic> json) =
+      _$NotificationDataModelImpl.fromJson;
+
+  @override
+  String get id;
+  @override
+  @JsonKey(name: 'event_id')
+  String get eventId;
+  @override
+  String get title;
+  @override
+  String get location;
+  @override
+  DateTime get datetime;
+  @override
+  bool get read;
+
+  /// Create a copy of NotificationDataModel
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$NotificationDataModelImplCopyWith<_$NotificationDataModelImpl>
+  get copyWith => throw _privateConstructorUsedError;
+}

--- a/lib/data/models/notification_data_model.g.dart
+++ b/lib/data/models/notification_data_model.g.dart
@@ -1,0 +1,29 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'notification_data_model.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$NotificationDataModelImpl _$$NotificationDataModelImplFromJson(
+  Map<String, dynamic> json,
+) => _$NotificationDataModelImpl(
+  id: json['id'] as String,
+  eventId: json['event_id'] as String,
+  title: json['title'] as String,
+  location: json['location'] as String,
+  datetime: DateTime.parse(json['datetime'] as String),
+  read: json['read'] as bool,
+);
+
+Map<String, dynamic> _$$NotificationDataModelImplToJson(
+  _$NotificationDataModelImpl instance,
+) => <String, dynamic>{
+  'id': instance.id,
+  'event_id': instance.eventId,
+  'title': instance.title,
+  'location': instance.location,
+  'datetime': instance.datetime.toIso8601String(),
+  'read': instance.read,
+};

--- a/lib/data/notifications/notifications_gateway.dart
+++ b/lib/data/notifications/notifications_gateway.dart
@@ -1,0 +1,10 @@
+import '../../application/models/paginated_result.dart';
+import '../models/notification_data_model.dart';
+
+abstract interface class NotificationsGateway {
+  Future<PaginatedResult<NotificationDataModel>> loadNotifications({
+    String? cursor,
+    int limit,
+  });
+  Future<int> loadUnreadCount();
+}

--- a/lib/data/notifications/notifications_gateway_impl.dart
+++ b/lib/data/notifications/notifications_gateway_impl.dart
@@ -1,0 +1,55 @@
+import 'package:dio/dio.dart';
+
+import '../../application/models/paginated_result.dart';
+import '../common/dio_options_manager.dart';
+import '../models/notification_data_model.dart';
+import '../paths.dart';
+import 'notifications_gateway.dart';
+
+class NotificationsGatewayImpl implements NotificationsGateway {
+  NotificationsGatewayImpl(this._dio, this._optionsManager);
+
+  final Dio _dio;
+  final DioOptionsManager _optionsManager;
+
+  @override
+  Future<PaginatedResult<NotificationDataModel>> loadNotifications({
+    String? cursor,
+    int limit = 50,
+  }) async {
+    try {
+      final resp = await _dio.get(
+        Paths.notifications,
+        options: _optionsManager.opts(),
+        queryParameters: {
+          if (cursor != null) 'cursor': cursor,
+          'limit': limit,
+        },
+      );
+      final data = resp.data;
+      if (data is! Map<String, dynamic> || data['items'] is! List) {
+        return const PaginatedResult(items: []);
+      }
+      return PaginatedResult.fromJson(
+        data,
+        (e) => NotificationDataModel.fromJson(e as Map<String, dynamic>),
+      );
+    } catch (_) {
+      return const PaginatedResult(items: []);
+    }
+  }
+
+  @override
+  Future<int> loadUnreadCount() async {
+    try {
+      final resp = await _dio.get(
+        Paths.notificationsUnreadCount,
+        options: _optionsManager.opts(),
+      );
+      final data = resp.data as Map<String, dynamic>;
+      return data['count'] as int? ?? 0;
+    } catch (_) {
+      return 0;
+    }
+  }
+}

--- a/lib/data/paths.dart
+++ b/lib/data/paths.dart
@@ -29,4 +29,7 @@ abstract class Paths {
   static const String _cities = '/api/v1/cities';
   static String coordinates = '$_cities/coordinates';
   static String search = '$_cities/search';
+
+  static const String notifications = '/api/v1/notifications/';
+  static String notificationsUnreadCount = '${notifications}unread-count';
 }

--- a/lib/presentation/blocs/notifications/notifications_cubit.dart
+++ b/lib/presentation/blocs/notifications/notifications_cubit.dart
@@ -1,0 +1,47 @@
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+import '../../../application/repositories/notifications/notifications_repository.dart';
+import '../../common/models/loaded_state.dart';
+import 'notifications_state.dart';
+
+class NotificationsCubit extends Cubit<NotificationsState> {
+  NotificationsCubit(this._repository) : super(const NotificationsState());
+
+  final NotificationsRepository _repository;
+
+  /// The panel shows at least the last few read notifications alongside
+  /// the unread ones — read ones just render lighter. This is a floor on
+  /// how many *read* notifications pad out the list, not a hard cap: every
+  /// unread notification is always shown, however many there are.
+  static const _minDisplayed = 10;
+
+  /// Cheap poll for the bell badge — does not mark anything as read.
+  Future<void> loadUnreadCount() async {
+    final count = await _repository.getUnreadCount();
+    emit(state.copyWith(unreadCount: count));
+  }
+
+  /// Loads the list (soonest-first). Per the backend, this marks every
+  /// currently unread notification as read, so the badge is cleared
+  /// locally too — they won't show as "new" again on a later session,
+  /// though they stay visible in the panel (just lighter).
+  Future<void> loadNotifications() async {
+    emit(state.copyWith(list: const LoadedState.loading()));
+    final notifications = await _repository.getNotifications();
+
+    final unread = notifications.where((n) => !n.read);
+    final read = notifications.where((n) => n.read);
+    final readSlots = _minDisplayed - unread.length;
+    final displayed = [
+      ...unread,
+      ...read.take(readSlots > 0 ? readSlots : 0),
+    ];
+
+    emit(
+      state.copyWith(
+        list: LoadedState.data(displayed),
+        unreadCount: 0,
+      ),
+    );
+  }
+}

--- a/lib/presentation/blocs/notifications/notifications_cubit.dart
+++ b/lib/presentation/blocs/notifications/notifications_cubit.dart
@@ -21,6 +21,12 @@ class NotificationsCubit extends Cubit<NotificationsState> {
     emit(state.copyWith(unreadCount: count));
   }
 
+  void clearUnreadCount() {
+    if (state.unreadCount > 0) {
+      emit(state.copyWith(unreadCount: 0));
+    }
+  }
+
   /// Loads the list (soonest-first). Per the backend, this marks every
   /// currently unread notification as read, so the badge is cleared
   /// locally too — they won't show as "new" again on a later session,
@@ -40,7 +46,6 @@ class NotificationsCubit extends Cubit<NotificationsState> {
     emit(
       state.copyWith(
         list: LoadedState.data(displayed),
-        unreadCount: 0,
       ),
     );
   }

--- a/lib/presentation/blocs/notifications/notifications_state.dart
+++ b/lib/presentation/blocs/notifications/notifications_state.dart
@@ -1,0 +1,14 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+import '../../../application/models/notification.dart';
+import '../../common/models/loaded_state.dart';
+
+part 'notifications_state.freezed.dart';
+
+@freezed
+class NotificationsState with _$NotificationsState {
+  const factory NotificationsState({
+    @Default(0) int unreadCount,
+    @Default(LoadedState.init()) LoadedState<List<NotificationModel>> list,
+  }) = _NotificationsState;
+}

--- a/lib/presentation/blocs/notifications/notifications_state.freezed.dart
+++ b/lib/presentation/blocs/notifications/notifications_state.freezed.dart
@@ -1,0 +1,196 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'notifications_state.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+  'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models',
+);
+
+/// @nodoc
+mixin _$NotificationsState {
+  int get unreadCount => throw _privateConstructorUsedError;
+  LoadedState<List<NotificationModel>> get list =>
+      throw _privateConstructorUsedError;
+
+  /// Create a copy of NotificationsState
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  $NotificationsStateCopyWith<NotificationsState> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $NotificationsStateCopyWith<$Res> {
+  factory $NotificationsStateCopyWith(
+    NotificationsState value,
+    $Res Function(NotificationsState) then,
+  ) = _$NotificationsStateCopyWithImpl<$Res, NotificationsState>;
+  @useResult
+  $Res call({int unreadCount, LoadedState<List<NotificationModel>> list});
+
+  $LoadedStateCopyWith<List<NotificationModel>, $Res> get list;
+}
+
+/// @nodoc
+class _$NotificationsStateCopyWithImpl<$Res, $Val extends NotificationsState>
+    implements $NotificationsStateCopyWith<$Res> {
+  _$NotificationsStateCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of NotificationsState
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({Object? unreadCount = null, Object? list = null}) {
+    return _then(
+      _value.copyWith(
+            unreadCount:
+                null == unreadCount
+                    ? _value.unreadCount
+                    : unreadCount // ignore: cast_nullable_to_non_nullable
+                        as int,
+            list:
+                null == list
+                    ? _value.list
+                    : list // ignore: cast_nullable_to_non_nullable
+                        as LoadedState<List<NotificationModel>>,
+          )
+          as $Val,
+    );
+  }
+
+  /// Create a copy of NotificationsState
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $LoadedStateCopyWith<List<NotificationModel>, $Res> get list {
+    return $LoadedStateCopyWith<List<NotificationModel>, $Res>(_value.list, (
+      value,
+    ) {
+      return _then(_value.copyWith(list: value) as $Val);
+    });
+  }
+}
+
+/// @nodoc
+abstract class _$$NotificationsStateImplCopyWith<$Res>
+    implements $NotificationsStateCopyWith<$Res> {
+  factory _$$NotificationsStateImplCopyWith(
+    _$NotificationsStateImpl value,
+    $Res Function(_$NotificationsStateImpl) then,
+  ) = __$$NotificationsStateImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({int unreadCount, LoadedState<List<NotificationModel>> list});
+
+  @override
+  $LoadedStateCopyWith<List<NotificationModel>, $Res> get list;
+}
+
+/// @nodoc
+class __$$NotificationsStateImplCopyWithImpl<$Res>
+    extends _$NotificationsStateCopyWithImpl<$Res, _$NotificationsStateImpl>
+    implements _$$NotificationsStateImplCopyWith<$Res> {
+  __$$NotificationsStateImplCopyWithImpl(
+    _$NotificationsStateImpl _value,
+    $Res Function(_$NotificationsStateImpl) _then,
+  ) : super(_value, _then);
+
+  /// Create a copy of NotificationsState
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({Object? unreadCount = null, Object? list = null}) {
+    return _then(
+      _$NotificationsStateImpl(
+        unreadCount:
+            null == unreadCount
+                ? _value.unreadCount
+                : unreadCount // ignore: cast_nullable_to_non_nullable
+                    as int,
+        list:
+            null == list
+                ? _value.list
+                : list // ignore: cast_nullable_to_non_nullable
+                    as LoadedState<List<NotificationModel>>,
+      ),
+    );
+  }
+}
+
+/// @nodoc
+
+class _$NotificationsStateImpl implements _NotificationsState {
+  const _$NotificationsStateImpl({
+    this.unreadCount = 0,
+    this.list = const LoadedState.init(),
+  });
+
+  @override
+  @JsonKey()
+  final int unreadCount;
+  @override
+  @JsonKey()
+  final LoadedState<List<NotificationModel>> list;
+
+  @override
+  String toString() {
+    return 'NotificationsState(unreadCount: $unreadCount, list: $list)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$NotificationsStateImpl &&
+            (identical(other.unreadCount, unreadCount) ||
+                other.unreadCount == unreadCount) &&
+            (identical(other.list, list) || other.list == list));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, unreadCount, list);
+
+  /// Create a copy of NotificationsState
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$NotificationsStateImplCopyWith<_$NotificationsStateImpl> get copyWith =>
+      __$$NotificationsStateImplCopyWithImpl<_$NotificationsStateImpl>(
+        this,
+        _$identity,
+      );
+}
+
+abstract class _NotificationsState implements NotificationsState {
+  const factory _NotificationsState({
+    final int unreadCount,
+    final LoadedState<List<NotificationModel>> list,
+  }) = _$NotificationsStateImpl;
+
+  @override
+  int get unreadCount;
+  @override
+  LoadedState<List<NotificationModel>> get list;
+
+  /// Create a copy of NotificationsState
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$NotificationsStateImplCopyWith<_$NotificationsStateImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/presentation/blocs/one_event/one_event_cubit.dart
+++ b/lib/presentation/blocs/one_event/one_event_cubit.dart
@@ -55,22 +55,39 @@ class OneEventCubit extends Cubit<OneEventState> {
     state.event.map((s) => s.eventId).map(_repository.deleteEvent);
   }
 
+  /// Fields the backend rejects when blank; checked here so the user finds
+  /// out before a round trip instead of getting a generic save failure.
+  String? _validationError(EventModel event) {
+    final missing = <String>[
+      if ((event.description ?? '').trim().isEmpty) 'Description',
+      if ((event.location ?? '').trim().isEmpty) 'Location',
+    ];
+    if (missing.isEmpty) {
+      return null;
+    }
+    return 'Please fill in: ${missing.join(', ')}.';
+  }
+
   Future<void> save() async {
     state.event.map(
       (event) =>
           _reporter.reportSaveEvent(event, AppLocation.eventEditingScreen),
     );
+
+    final validationError = state.event.match(() => null, _validationError);
+    if (validationError != null) {
+      emit(state.copyWith(saveState: LoadedState.error(validationError)));
+      return;
+    }
+
     emit(state.copyWith(saveState: const LoadedState.loading()));
     state.event.map(_repository.modifyEvent);
-    final newId = await _repository.save();
+    final result = await _repository.save();
     emit(
       state.copyWith(
-        saveState: newId.match(
-          () => const LoadedState.error('Could not save the event'),
-          (_) => const LoadedState.data(unit),
-        ),
-        event: newId.match(
-          () => state.event,
+        saveState: result.match(LoadedState.error, (_) => const LoadedState.data(unit)),
+        event: result.match(
+          (_) => state.event,
           (id) => state.event.map((e) => e.copyWith(eventId: id)),
         ),
       ),

--- a/lib/presentation/pages/events_list/events_list_page.dart
+++ b/lib/presentation/pages/events_list/events_list_page.dart
@@ -5,6 +5,9 @@ import 'package:fpdart/fpdart.dart' hide State;
 
 import '../../../application/repositories/reporter/reporter.dart';
 import '../../blocs/events_list/events_list_cubit.dart';
+import '../../blocs/notifications/notifications_cubit.dart';
+import '../../blocs/notifications/notifications_state.dart';
+import '../../common/constants/app_colors.dart';
 import '../../common/constants/app_text_styles.dart';
 import '../../common/widgets/app_button.dart';
 import '../../common/widgets/app_loader.dart';
@@ -23,6 +26,7 @@ class _EventsListPageState extends State<EventsListPage> {
   @override
   void initState() {
     context.read<EventsListCubit>().loadEvents();
+    context.read<NotificationsCubit>().loadUnreadCount();
     super.initState();
   }
 
@@ -41,6 +45,33 @@ class _EventsListPageState extends State<EventsListPage> {
           context.read<Reporter>().reportCreateEventTap(AppLocation.eventsTab);
           context.pushRoute(EventEditingRoute(eventId: const None()));
         },
+      ),
+      AppButton(
+        is48Height: true,
+        buttonStyle: AppButtonStyle.gray,
+        onTap: () => context.pushRoute(const NotificationsRoute()),
+        child: BlocBuilder<NotificationsCubit, NotificationsState>(
+          buildWhen: (p, c) => p.unreadCount != c.unreadCount,
+          builder: (context, state) => Stack(
+            clipBehavior: Clip.none,
+            children: [
+              const Icon(Icons.notifications_outlined, color: AppColors.darkGray),
+              if (state.unreadCount > 0)
+                Positioned(
+                  right: -2,
+                  top: -2,
+                  child: Container(
+                    width: 10,
+                    height: 10,
+                    decoration: const BoxDecoration(
+                      color: AppColors.error,
+                      shape: BoxShape.circle,
+                    ),
+                  ),
+                ),
+            ],
+          ),
+        ),
       ),
     ],
     body: AppChildBody(

--- a/lib/presentation/pages/notifications/notifications_page.dart
+++ b/lib/presentation/pages/notifications/notifications_page.dart
@@ -1,0 +1,54 @@
+import 'package:auto_route/auto_route.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+import '../../blocs/notifications/notifications_cubit.dart';
+import '../../blocs/notifications/notifications_state.dart';
+import '../../common/constants/app_text_styles.dart';
+import '../../common/models/loaded_state.dart';
+import '../../common/widgets/app_loader.dart';
+import '../../common/widgets/app_scaffold.dart';
+import 'widgets/notification_tile.dart';
+
+@RoutePage()
+class NotificationsPage extends StatefulWidget {
+  const NotificationsPage({super.key});
+
+  @override
+  State<NotificationsPage> createState() => _NotificationsPageState();
+}
+
+class _NotificationsPageState extends State<NotificationsPage> {
+  @override
+  void initState() {
+    context.read<NotificationsCubit>().loadNotifications();
+    super.initState();
+  }
+
+  @override
+  Widget build(BuildContext context) => AppScaffold(
+    title: 'Notifications',
+    body: AppChildBody(
+      padding: EdgeInsets.zero,
+      child: BlocBuilder<NotificationsCubit, NotificationsState>(
+        builder: (context, state) => switch (state.list) {
+          LoadedStateData(:final data) when data.isEmpty => Center(
+            child: Text('No notifications', style: AppTextStyles.caption),
+          ),
+          LoadedStateData(:final data) => ListView.separated(
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 16),
+            physics: const BouncingScrollPhysics(),
+            itemCount: data.length,
+            separatorBuilder: (_, _) => const SizedBox(height: 8),
+            itemBuilder: (context, i) =>
+                NotificationTile(notification: data[i]),
+          ),
+          LoadedStateError(:final error) => Center(
+            child: Text(error, style: AppTextStyles.caption),
+          ),
+          _ => const Center(child: AppLoader(inCard: true)),
+        },
+      ),
+    ),
+  );
+}

--- a/lib/presentation/pages/notifications/notifications_page.dart
+++ b/lib/presentation/pages/notifications/notifications_page.dart
@@ -21,7 +21,9 @@ class NotificationsPage extends StatefulWidget {
 class _NotificationsPageState extends State<NotificationsPage> {
   @override
   void initState() {
-    context.read<NotificationsCubit>().loadNotifications();
+    final notificationsCubit = context.read<NotificationsCubit>();
+    notificationsCubit.clearUnreadCount();
+    notificationsCubit.loadNotifications();
     super.initState();
   }
 

--- a/lib/presentation/pages/notifications/widgets/notification_tile.dart
+++ b/lib/presentation/pages/notifications/widgets/notification_tile.dart
@@ -1,0 +1,120 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+
+import '../../../../application/models/notification.dart';
+import '../../../common/constants/app_colors.dart';
+import '../../../common/constants/app_text_styles.dart';
+
+class NotificationTile extends StatefulWidget {
+  const NotificationTile({required this.notification, super.key});
+
+  final NotificationModel notification;
+
+  @override
+  State<NotificationTile> createState() => _NotificationTileState();
+}
+
+class _NotificationTileState extends State<NotificationTile> {
+  bool _expanded = false;
+  late final _formatter = DateFormat('dd.MM.yyyy, HH:mm');
+
+  @override
+  Widget build(BuildContext context) => Material(
+    borderRadius: BorderRadius.circular(16),
+    // Unread notifications render darker so they stand out from the
+    // already-read ones the panel keeps showing alongside them.
+    color: widget.notification.read ? AppColors.gray90 : AppColors.gray80,
+    child: InkWell(
+      borderRadius: BorderRadius.circular(16),
+      onTap: () => setState(() => _expanded = !_expanded),
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Row(
+              children: [
+                if (!widget.notification.read)
+                  Container(
+                    width: 8,
+                    height: 8,
+                    margin: const EdgeInsets.only(right: 8),
+                    decoration: const BoxDecoration(
+                      color: AppColors.primary,
+                      shape: BoxShape.circle,
+                    ),
+                  ),
+                const Icon(Icons.event_outlined, color: Colors.black38),
+                const SizedBox(width: 8),
+                const Expanded(
+                  child: Text(
+                    'An event is happening near you soon',
+                    style: AppTextStyles.body,
+                  ),
+                ),
+                Icon(
+                  _expanded ? Icons.expand_less : Icons.expand_more,
+                  color: Colors.black38,
+                ),
+              ],
+            ),
+            AnimatedSize(
+              duration: const Duration(milliseconds: 200),
+              alignment: Alignment.topCenter,
+              child: _expanded
+                  ? Padding(
+                      padding: const EdgeInsets.only(top: 12),
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        spacing: 6,
+                        children: [
+                          Text(
+                            widget.notification.title,
+                            style: AppTextStyles.subtitle,
+                          ),
+                          Row(
+                            children: [
+                              const Icon(
+                                Icons.calendar_month_outlined,
+                                size: 18,
+                                color: Colors.black38,
+                              ),
+                              const SizedBox(width: 4),
+                              Text(
+                                _formatter.format(widget.notification.datetime),
+                                style: AppTextStyles.caption.copyWith(
+                                  color: Colors.black38,
+                                ),
+                              ),
+                            ],
+                          ),
+                          Row(
+                            children: [
+                              const Icon(
+                                Icons.location_pin,
+                                size: 18,
+                                color: Colors.black38,
+                              ),
+                              const SizedBox(width: 4),
+                              Expanded(
+                                child: Text(
+                                  widget.notification.location,
+                                  style: AppTextStyles.caption.copyWith(
+                                    color: Colors.black38,
+                                  ),
+                                  overflow: TextOverflow.ellipsis,
+                                ),
+                              ),
+                            ],
+                          ),
+                        ],
+                      ),
+                    )
+                  : const SizedBox.shrink(),
+            ),
+          ],
+        ),
+      ),
+    ),
+  );
+}

--- a/lib/presentation/router/app_router.dart
+++ b/lib/presentation/router/app_router.dart
@@ -29,6 +29,7 @@ class AppRouter extends RootStackRouter {
     AutoRoute(page: AppLoadingRoute.page, initial: true),
     AutoRoute(page: ProfileRoute.page),
     AutoRoute(page: CityDataRoute.page),
+    AutoRoute(page: NotificationsRoute.page),
   ];
 
   @override

--- a/lib/presentation/router/app_router.gr.dart
+++ b/lib/presentation/router/app_router.gr.dart
@@ -9,91 +9,93 @@
 // coverage:ignore-file
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
-import 'package:auto_route/auto_route.dart' as _i21;
-import 'package:flutter/cupertino.dart' as _i23;
-import 'package:flutter/material.dart' as _i24;
+import 'package:auto_route/auto_route.dart' as _i22;
+import 'package:flutter/cupertino.dart' as _i24;
+import 'package:flutter/material.dart' as _i25;
 import 'package:fpdart/fpdart.dart' as _i6;
-import 'package:ui_alumni_mobile/application/models/profile.dart' as _i25;
+import 'package:ui_alumni_mobile/application/models/profile.dart' as _i26;
 import 'package:ui_alumni_mobile/application/repositories/map/map_repository.dart'
-    as _i22;
+    as _i23;
 import 'package:ui_alumni_mobile/presentation/pages/app_loading/app_loading_page.dart'
     as _i1;
 import 'package:ui_alumni_mobile/presentation/pages/auth/auth_page.dart' as _i2;
 import 'package:ui_alumni_mobile/presentation/pages/auth/subpages/code_verification_sub_page.dart'
     as _i4;
 import 'package:ui_alumni_mobile/presentation/pages/auth/subpages/otp_request_sub_page.dart'
-    as _i8;
-import 'package:ui_alumni_mobile/presentation/pages/auth/subpages/otp_verify_sub_page.dart'
     as _i9;
+import 'package:ui_alumni_mobile/presentation/pages/auth/subpages/otp_verify_sub_page.dart'
+    as _i10;
 import 'package:ui_alumni_mobile/presentation/pages/auth/subpages/password_reset_request_sub_page.dart'
-    as _i11;
+    as _i12;
 import 'package:ui_alumni_mobile/presentation/pages/auth/subpages/registration_sub_page.dart'
-    as _i14;
-import 'package:ui_alumni_mobile/presentation/pages/auth/subpages/restored_verification_sub_page.dart'
     as _i15;
+import 'package:ui_alumni_mobile/presentation/pages/auth/subpages/restored_verification_sub_page.dart'
+    as _i16;
 import 'package:ui_alumni_mobile/presentation/pages/auth/subpages/sign_in_sub_page.dart'
-    as _i17;
-import 'package:ui_alumni_mobile/presentation/pages/auth/subpages/telegram_otp_request_sub_page.dart'
     as _i18;
-import 'package:ui_alumni_mobile/presentation/pages/auth/subpages/telegram_otp_verify_sub_page.dart'
+import 'package:ui_alumni_mobile/presentation/pages/auth/subpages/telegram_otp_request_sub_page.dart'
     as _i19;
-import 'package:ui_alumni_mobile/presentation/pages/auth/subpages/verification_way_sub_page.dart'
+import 'package:ui_alumni_mobile/presentation/pages/auth/subpages/telegram_otp_verify_sub_page.dart'
     as _i20;
+import 'package:ui_alumni_mobile/presentation/pages/auth/subpages/verification_way_sub_page.dart'
+    as _i21;
 import 'package:ui_alumni_mobile/presentation/pages/city_data/city_data.dart'
     as _i3;
 import 'package:ui_alumni_mobile/presentation/pages/event/event_page.dart'
     as _i7;
 import 'package:ui_alumni_mobile/presentation/pages/event_editing/event_editing_page.dart'
     as _i5;
+import 'package:ui_alumni_mobile/presentation/pages/notifications/notifications_page.dart'
+    as _i8;
 import 'package:ui_alumni_mobile/presentation/pages/password_reset/password_reset_confirm_page.dart'
-    as _i10;
+    as _i11;
 import 'package:ui_alumni_mobile/presentation/pages/profile/profile_page.dart'
-    as _i13;
+    as _i14;
 import 'package:ui_alumni_mobile/presentation/pages/profile_editing/profile_editing_page.dart'
-    as _i12;
+    as _i13;
 import 'package:ui_alumni_mobile/presentation/pages/root/root_page.dart'
-    as _i16;
+    as _i17;
 
 /// generated route for
 /// [_i1.AppLoadingPage]
-class AppLoadingRoute extends _i21.PageRouteInfo<void> {
-  const AppLoadingRoute({List<_i21.PageRouteInfo>? children})
+class AppLoadingRoute extends _i22.PageRouteInfo<void> {
+  const AppLoadingRoute({List<_i22.PageRouteInfo>? children})
     : super(AppLoadingRoute.name, initialChildren: children);
 
   static const String name = 'AppLoadingRoute';
 
-  static _i21.PageInfo page = _i21.PageInfo(
+  static _i22.PageInfo page = _i22.PageInfo(
     name,
     builder: (data) {
-      return _i21.WrappedRoute(child: const _i1.AppLoadingPage());
+      return _i22.WrappedRoute(child: const _i1.AppLoadingPage());
     },
   );
 }
 
 /// generated route for
 /// [_i2.AuthPage]
-class AuthRoute extends _i21.PageRouteInfo<void> {
-  const AuthRoute({List<_i21.PageRouteInfo>? children})
+class AuthRoute extends _i22.PageRouteInfo<void> {
+  const AuthRoute({List<_i22.PageRouteInfo>? children})
     : super(AuthRoute.name, initialChildren: children);
 
   static const String name = 'AuthRoute';
 
-  static _i21.PageInfo page = _i21.PageInfo(
+  static _i22.PageInfo page = _i22.PageInfo(
     name,
     builder: (data) {
-      return _i21.WrappedRoute(child: const _i2.AuthPage());
+      return _i22.WrappedRoute(child: const _i2.AuthPage());
     },
   );
 }
 
 /// generated route for
 /// [_i3.CityDataPage]
-class CityDataRoute extends _i21.PageRouteInfo<CityDataRouteArgs> {
+class CityDataRoute extends _i22.PageRouteInfo<CityDataRouteArgs> {
   CityDataRoute({
-    required _i22.CityData cityData,
-    required _i22.NamedCoordinates coords,
-    _i23.Key? key,
-    List<_i21.PageRouteInfo>? children,
+    required _i23.CityData cityData,
+    required _i23.NamedCoordinates coords,
+    _i24.Key? key,
+    List<_i22.PageRouteInfo>? children,
   }) : super(
          CityDataRoute.name,
          args: CityDataRouteArgs(cityData: cityData, coords: coords, key: key),
@@ -102,7 +104,7 @@ class CityDataRoute extends _i21.PageRouteInfo<CityDataRouteArgs> {
 
   static const String name = 'CityDataRoute';
 
-  static _i21.PageInfo page = _i21.PageInfo(
+  static _i22.PageInfo page = _i22.PageInfo(
     name,
     builder: (data) {
       final args = data.argsAs<CityDataRouteArgs>();
@@ -122,11 +124,11 @@ class CityDataRouteArgs {
     this.key,
   });
 
-  final _i22.CityData cityData;
+  final _i23.CityData cityData;
 
-  final _i22.NamedCoordinates coords;
+  final _i23.NamedCoordinates coords;
 
-  final _i23.Key? key;
+  final _i24.Key? key;
 
   @override
   String toString() {
@@ -136,13 +138,13 @@ class CityDataRouteArgs {
 
 /// generated route for
 /// [_i4.CodeVerificationSubPage]
-class CodeVerificationSubRoute extends _i21.PageRouteInfo<void> {
-  const CodeVerificationSubRoute({List<_i21.PageRouteInfo>? children})
+class CodeVerificationSubRoute extends _i22.PageRouteInfo<void> {
+  const CodeVerificationSubRoute({List<_i22.PageRouteInfo>? children})
     : super(CodeVerificationSubRoute.name, initialChildren: children);
 
   static const String name = 'CodeVerificationSubRoute';
 
-  static _i21.PageInfo page = _i21.PageInfo(
+  static _i22.PageInfo page = _i22.PageInfo(
     name,
     builder: (data) {
       return const _i4.CodeVerificationSubPage();
@@ -152,12 +154,12 @@ class CodeVerificationSubRoute extends _i21.PageRouteInfo<void> {
 
 /// generated route for
 /// [_i5.EventEditingPage]
-class EventEditingRoute extends _i21.PageRouteInfo<EventEditingRouteArgs> {
+class EventEditingRoute extends _i22.PageRouteInfo<EventEditingRouteArgs> {
   EventEditingRoute({
     required _i6.Option<String> eventId,
     _i6.Option<String> location = const _i6.None(),
-    _i24.Key? key,
-    List<_i21.PageRouteInfo>? children,
+    _i25.Key? key,
+    List<_i22.PageRouteInfo>? children,
   }) : super(
          EventEditingRoute.name,
          args: EventEditingRouteArgs(
@@ -170,11 +172,11 @@ class EventEditingRoute extends _i21.PageRouteInfo<EventEditingRouteArgs> {
 
   static const String name = 'EventEditingRoute';
 
-  static _i21.PageInfo page = _i21.PageInfo(
+  static _i22.PageInfo page = _i22.PageInfo(
     name,
     builder: (data) {
       final args = data.argsAs<EventEditingRouteArgs>();
-      return _i21.WrappedRoute(
+      return _i22.WrappedRoute(
         child: _i5.EventEditingPage(
           eventId: args.eventId,
           location: args.location,
@@ -196,7 +198,7 @@ class EventEditingRouteArgs {
 
   final _i6.Option<String> location;
 
-  final _i24.Key? key;
+  final _i25.Key? key;
 
   @override
   String toString() {
@@ -206,11 +208,11 @@ class EventEditingRouteArgs {
 
 /// generated route for
 /// [_i7.EventPage]
-class EventRoute extends _i21.PageRouteInfo<EventRouteArgs> {
+class EventRoute extends _i22.PageRouteInfo<EventRouteArgs> {
   EventRoute({
     required String eventId,
-    _i24.Key? key,
-    List<_i21.PageRouteInfo>? children,
+    _i25.Key? key,
+    List<_i22.PageRouteInfo>? children,
   }) : super(
          EventRoute.name,
          args: EventRouteArgs(eventId: eventId, key: key),
@@ -219,11 +221,11 @@ class EventRoute extends _i21.PageRouteInfo<EventRouteArgs> {
 
   static const String name = 'EventRoute';
 
-  static _i21.PageInfo page = _i21.PageInfo(
+  static _i22.PageInfo page = _i22.PageInfo(
     name,
     builder: (data) {
       final args = data.argsAs<EventRouteArgs>();
-      return _i21.WrappedRoute(
+      return _i22.WrappedRoute(
         child: _i7.EventPage(eventId: args.eventId, key: args.key),
       );
     },
@@ -235,7 +237,7 @@ class EventRouteArgs {
 
   final String eventId;
 
-  final _i24.Key? key;
+  final _i25.Key? key;
 
   @override
   String toString() {
@@ -244,12 +246,28 @@ class EventRouteArgs {
 }
 
 /// generated route for
-/// [_i8.OtpRequestSubPage]
-class OtpRequestSubRoute extends _i21.PageRouteInfo<OtpRequestSubRouteArgs> {
+/// [_i8.NotificationsPage]
+class NotificationsRoute extends _i22.PageRouteInfo<void> {
+  const NotificationsRoute({List<_i22.PageRouteInfo>? children})
+    : super(NotificationsRoute.name, initialChildren: children);
+
+  static const String name = 'NotificationsRoute';
+
+  static _i22.PageInfo page = _i22.PageInfo(
+    name,
+    builder: (data) {
+      return const _i8.NotificationsPage();
+    },
+  );
+}
+
+/// generated route for
+/// [_i9.OtpRequestSubPage]
+class OtpRequestSubRoute extends _i22.PageRouteInfo<OtpRequestSubRouteArgs> {
   OtpRequestSubRoute({
-    _i24.Key? key,
+    _i25.Key? key,
     String email = '',
-    List<_i21.PageRouteInfo>? children,
+    List<_i22.PageRouteInfo>? children,
   }) : super(
          OtpRequestSubRoute.name,
          args: OtpRequestSubRouteArgs(key: key, email: email),
@@ -258,13 +276,13 @@ class OtpRequestSubRoute extends _i21.PageRouteInfo<OtpRequestSubRouteArgs> {
 
   static const String name = 'OtpRequestSubRoute';
 
-  static _i21.PageInfo page = _i21.PageInfo(
+  static _i22.PageInfo page = _i22.PageInfo(
     name,
     builder: (data) {
       final args = data.argsAs<OtpRequestSubRouteArgs>(
         orElse: () => const OtpRequestSubRouteArgs(),
       );
-      return _i8.OtpRequestSubPage(key: args.key, email: args.email);
+      return _i9.OtpRequestSubPage(key: args.key, email: args.email);
     },
   );
 }
@@ -272,7 +290,7 @@ class OtpRequestSubRoute extends _i21.PageRouteInfo<OtpRequestSubRouteArgs> {
 class OtpRequestSubRouteArgs {
   const OtpRequestSubRouteArgs({this.key, this.email = ''});
 
-  final _i24.Key? key;
+  final _i25.Key? key;
 
   final String email;
 
@@ -283,100 +301,100 @@ class OtpRequestSubRouteArgs {
 }
 
 /// generated route for
-/// [_i9.OtpVerifySubPage]
-class OtpVerifySubRoute extends _i21.PageRouteInfo<void> {
-  const OtpVerifySubRoute({List<_i21.PageRouteInfo>? children})
+/// [_i10.OtpVerifySubPage]
+class OtpVerifySubRoute extends _i22.PageRouteInfo<void> {
+  const OtpVerifySubRoute({List<_i22.PageRouteInfo>? children})
     : super(OtpVerifySubRoute.name, initialChildren: children);
 
   static const String name = 'OtpVerifySubRoute';
 
-  static _i21.PageInfo page = _i21.PageInfo(
+  static _i22.PageInfo page = _i22.PageInfo(
     name,
     builder: (data) {
-      return const _i9.OtpVerifySubPage();
+      return const _i10.OtpVerifySubPage();
     },
   );
 }
 
 /// generated route for
-/// [_i10.PasswordResetConfirmPage]
+/// [_i11.PasswordResetConfirmPage]
 class PasswordResetConfirmRoute
-    extends _i21.PageRouteInfo<PasswordResetConfirmRouteArgs> {
+    extends _i22.PageRouteInfo<PasswordResetConfirmRouteArgs> {
   PasswordResetConfirmRoute({
-    _i24.Key? key,
     required String token,
-    List<_i21.PageRouteInfo>? children,
+    _i25.Key? key,
+    List<_i22.PageRouteInfo>? children,
   }) : super(
          PasswordResetConfirmRoute.name,
-         args: PasswordResetConfirmRouteArgs(key: key, token: token),
+         args: PasswordResetConfirmRouteArgs(token: token, key: key),
          initialChildren: children,
        );
 
   static const String name = 'PasswordResetConfirmRoute';
 
-  static _i21.PageInfo page = _i21.PageInfo(
+  static _i22.PageInfo page = _i22.PageInfo(
     name,
     builder: (data) {
       final args = data.argsAs<PasswordResetConfirmRouteArgs>();
-      return _i21.WrappedRoute(
-        child: _i10.PasswordResetConfirmPage(key: args.key, token: args.token),
+      return _i22.WrappedRoute(
+        child: _i11.PasswordResetConfirmPage(token: args.token, key: args.key),
       );
     },
   );
 }
 
 class PasswordResetConfirmRouteArgs {
-  const PasswordResetConfirmRouteArgs({this.key, required this.token});
-
-  final _i24.Key? key;
+  const PasswordResetConfirmRouteArgs({required this.token, this.key});
 
   final String token;
 
+  final _i25.Key? key;
+
   @override
   String toString() {
-    return 'PasswordResetConfirmRouteArgs{key: $key, token: $token}';
+    return 'PasswordResetConfirmRouteArgs{token: $token, key: $key}';
   }
 }
 
 /// generated route for
-/// [_i11.PasswordResetRequestSubPage]
-class PasswordResetRequestSubRoute extends _i21.PageRouteInfo<void> {
-  const PasswordResetRequestSubRoute({List<_i21.PageRouteInfo>? children})
+/// [_i12.PasswordResetRequestSubPage]
+class PasswordResetRequestSubRoute extends _i22.PageRouteInfo<void> {
+  const PasswordResetRequestSubRoute({List<_i22.PageRouteInfo>? children})
     : super(PasswordResetRequestSubRoute.name, initialChildren: children);
 
   static const String name = 'PasswordResetRequestSubRoute';
 
-  static _i21.PageInfo page = _i21.PageInfo(
+  static _i22.PageInfo page = _i22.PageInfo(
     name,
     builder: (data) {
-      return const _i11.PasswordResetRequestSubPage();
+      return const _i12.PasswordResetRequestSubPage();
     },
   );
 }
 
 /// generated route for
-/// [_i12.ProfileEditingPage]
-class ProfileEditingRoute extends _i21.PageRouteInfo<void> {
-  const ProfileEditingRoute({List<_i21.PageRouteInfo>? children})
+/// [_i13.ProfileEditingPage]
+class ProfileEditingRoute extends _i22.PageRouteInfo<void> {
+  const ProfileEditingRoute({List<_i22.PageRouteInfo>? children})
     : super(ProfileEditingRoute.name, initialChildren: children);
 
   static const String name = 'ProfileEditingRoute';
 
-  static _i21.PageInfo page = _i21.PageInfo(
+  static _i22.PageInfo page = _i22.PageInfo(
     name,
     builder: (data) {
-      return _i21.WrappedRoute(child: const _i12.ProfileEditingPage());
+      return _i22.WrappedRoute(child: const _i13.ProfileEditingPage());
     },
   );
 }
 
 /// generated route for
-/// [_i13.ProfilePage]
-class ProfileRoute extends _i21.PageRouteInfo<ProfileRouteArgs> {
+/// [_i14.ProfilePage]
+class ProfileRoute extends _i22.PageRouteInfo<ProfileRouteArgs> {
   ProfileRoute({
-    _i6.Option<_i25.Profile> profile = const _i6.None(),
-    _i24.Key? key,
-    List<_i21.PageRouteInfo>? children,
+    _i6.Option<_i26.Profile> profile = const _i6.None(),
+    _i25.Key? key,
+    List<_i22.PageRouteInfo>? children,
   }) : super(
          ProfileRoute.name,
          args: ProfileRouteArgs(profile: profile, key: key),
@@ -385,14 +403,14 @@ class ProfileRoute extends _i21.PageRouteInfo<ProfileRouteArgs> {
 
   static const String name = 'ProfileRoute';
 
-  static _i21.PageInfo page = _i21.PageInfo(
+  static _i22.PageInfo page = _i22.PageInfo(
     name,
     builder: (data) {
       final args = data.argsAs<ProfileRouteArgs>(
         orElse: () => const ProfileRouteArgs(),
       );
-      return _i21.WrappedRoute(
-        child: _i13.ProfilePage(profile: args.profile, key: args.key),
+      return _i22.WrappedRoute(
+        child: _i14.ProfilePage(profile: args.profile, key: args.key),
       );
     },
   );
@@ -401,9 +419,9 @@ class ProfileRoute extends _i21.PageRouteInfo<ProfileRouteArgs> {
 class ProfileRouteArgs {
   const ProfileRouteArgs({this.profile = const _i6.None(), this.key});
 
-  final _i6.Option<_i25.Profile> profile;
+  final _i6.Option<_i26.Profile> profile;
 
-  final _i24.Key? key;
+  final _i25.Key? key;
 
   @override
   String toString() {
@@ -412,14 +430,14 @@ class ProfileRouteArgs {
 }
 
 /// generated route for
-/// [_i14.RegistrationSubPage]
+/// [_i15.RegistrationSubPage]
 class RegistrationSubRoute
-    extends _i21.PageRouteInfo<RegistrationSubRouteArgs> {
+    extends _i22.PageRouteInfo<RegistrationSubRouteArgs> {
   RegistrationSubRoute({
     required String email,
     required String password,
-    _i24.Key? key,
-    List<_i21.PageRouteInfo>? children,
+    _i25.Key? key,
+    List<_i22.PageRouteInfo>? children,
   }) : super(
          RegistrationSubRoute.name,
          args: RegistrationSubRouteArgs(
@@ -432,11 +450,11 @@ class RegistrationSubRoute
 
   static const String name = 'RegistrationSubRoute';
 
-  static _i21.PageInfo page = _i21.PageInfo(
+  static _i22.PageInfo page = _i22.PageInfo(
     name,
     builder: (data) {
       final args = data.argsAs<RegistrationSubRouteArgs>();
-      return _i14.RegistrationSubPage(
+      return _i15.RegistrationSubPage(
         email: args.email,
         password: args.password,
         key: args.key,
@@ -456,7 +474,7 @@ class RegistrationSubRouteArgs {
 
   final String password;
 
-  final _i24.Key? key;
+  final _i25.Key? key;
 
   @override
   String toString() {
@@ -465,61 +483,61 @@ class RegistrationSubRouteArgs {
 }
 
 /// generated route for
-/// [_i15.RestoredVerificationSubPage]
-class RestoredVerificationSubRoute extends _i21.PageRouteInfo<void> {
-  const RestoredVerificationSubRoute({List<_i21.PageRouteInfo>? children})
+/// [_i16.RestoredVerificationSubPage]
+class RestoredVerificationSubRoute extends _i22.PageRouteInfo<void> {
+  const RestoredVerificationSubRoute({List<_i22.PageRouteInfo>? children})
     : super(RestoredVerificationSubRoute.name, initialChildren: children);
 
   static const String name = 'RestoredVerificationSubRoute';
 
-  static _i21.PageInfo page = _i21.PageInfo(
+  static _i22.PageInfo page = _i22.PageInfo(
     name,
     builder: (data) {
-      return const _i15.RestoredVerificationSubPage();
+      return const _i16.RestoredVerificationSubPage();
     },
   );
 }
 
 /// generated route for
-/// [_i16.RootPage]
-class RootRoute extends _i21.PageRouteInfo<void> {
-  const RootRoute({List<_i21.PageRouteInfo>? children})
+/// [_i17.RootPage]
+class RootRoute extends _i22.PageRouteInfo<void> {
+  const RootRoute({List<_i22.PageRouteInfo>? children})
     : super(RootRoute.name, initialChildren: children);
 
   static const String name = 'RootRoute';
 
-  static _i21.PageInfo page = _i21.PageInfo(
+  static _i22.PageInfo page = _i22.PageInfo(
     name,
     builder: (data) {
-      return _i21.WrappedRoute(child: const _i16.RootPage());
+      return _i22.WrappedRoute(child: const _i17.RootPage());
     },
   );
 }
 
 /// generated route for
-/// [_i17.SignInSubPage]
-class SignInSubRoute extends _i21.PageRouteInfo<void> {
-  const SignInSubRoute({List<_i21.PageRouteInfo>? children})
+/// [_i18.SignInSubPage]
+class SignInSubRoute extends _i22.PageRouteInfo<void> {
+  const SignInSubRoute({List<_i22.PageRouteInfo>? children})
     : super(SignInSubRoute.name, initialChildren: children);
 
   static const String name = 'SignInSubRoute';
 
-  static _i21.PageInfo page = _i21.PageInfo(
+  static _i22.PageInfo page = _i22.PageInfo(
     name,
     builder: (data) {
-      return const _i17.SignInSubPage();
+      return const _i18.SignInSubPage();
     },
   );
 }
 
 /// generated route for
-/// [_i18.TelegramOtpRequestSubPage]
+/// [_i19.TelegramOtpRequestSubPage]
 class TelegramOtpRequestSubRoute
-    extends _i21.PageRouteInfo<TelegramOtpRequestSubRouteArgs> {
+    extends _i22.PageRouteInfo<TelegramOtpRequestSubRouteArgs> {
   TelegramOtpRequestSubRoute({
-    _i24.Key? key,
+    _i25.Key? key,
     String email = '',
-    List<_i21.PageRouteInfo>? children,
+    List<_i22.PageRouteInfo>? children,
   }) : super(
          TelegramOtpRequestSubRoute.name,
          args: TelegramOtpRequestSubRouteArgs(key: key, email: email),
@@ -528,13 +546,13 @@ class TelegramOtpRequestSubRoute
 
   static const String name = 'TelegramOtpRequestSubRoute';
 
-  static _i21.PageInfo page = _i21.PageInfo(
+  static _i22.PageInfo page = _i22.PageInfo(
     name,
     builder: (data) {
       final args = data.argsAs<TelegramOtpRequestSubRouteArgs>(
         orElse: () => const TelegramOtpRequestSubRouteArgs(),
       );
-      return _i18.TelegramOtpRequestSubPage(key: args.key, email: args.email);
+      return _i19.TelegramOtpRequestSubPage(key: args.key, email: args.email);
     },
   );
 }
@@ -542,7 +560,7 @@ class TelegramOtpRequestSubRoute
 class TelegramOtpRequestSubRouteArgs {
   const TelegramOtpRequestSubRouteArgs({this.key, this.email = ''});
 
-  final _i24.Key? key;
+  final _i25.Key? key;
 
   final String email;
 
@@ -553,33 +571,33 @@ class TelegramOtpRequestSubRouteArgs {
 }
 
 /// generated route for
-/// [_i19.TelegramOtpVerifySubPage]
-class TelegramOtpVerifySubRoute extends _i21.PageRouteInfo<void> {
-  const TelegramOtpVerifySubRoute({List<_i21.PageRouteInfo>? children})
+/// [_i20.TelegramOtpVerifySubPage]
+class TelegramOtpVerifySubRoute extends _i22.PageRouteInfo<void> {
+  const TelegramOtpVerifySubRoute({List<_i22.PageRouteInfo>? children})
     : super(TelegramOtpVerifySubRoute.name, initialChildren: children);
 
   static const String name = 'TelegramOtpVerifySubRoute';
 
-  static _i21.PageInfo page = _i21.PageInfo(
+  static _i22.PageInfo page = _i22.PageInfo(
     name,
     builder: (data) {
-      return const _i19.TelegramOtpVerifySubPage();
+      return const _i20.TelegramOtpVerifySubPage();
     },
   );
 }
 
 /// generated route for
-/// [_i20.VerificationWaySubPage]
-class VerificationWaySubRoute extends _i21.PageRouteInfo<void> {
-  const VerificationWaySubRoute({List<_i21.PageRouteInfo>? children})
+/// [_i21.VerificationWaySubPage]
+class VerificationWaySubRoute extends _i22.PageRouteInfo<void> {
+  const VerificationWaySubRoute({List<_i22.PageRouteInfo>? children})
     : super(VerificationWaySubRoute.name, initialChildren: children);
 
   static const String name = 'VerificationWaySubRoute';
 
-  static _i21.PageInfo page = _i21.PageInfo(
+  static _i22.PageInfo page = _i22.PageInfo(
     name,
     builder: (data) {
-      return const _i20.VerificationWaySubPage();
+      return const _i21.VerificationWaySubPage();
     },
   );
 }

--- a/test/unit/repositories/events/events_repository_impl_test.dart
+++ b/test/unit/repositories/events/events_repository_impl_test.dart
@@ -17,6 +17,8 @@ import 'events_repository_impl_test.mocks.dart';
 void _provideDummies() {
   provideDummy<Option<Profile>>(None());
   provideDummy<Option<String>>(None());
+  provideDummy<Either<String, String>>(const Left('dummy error'));
+  provideDummy<Either<String, Unit>>(const Left('dummy error'));
 }
 
 @GenerateMocks([EventsGateway, UsersRepository, Uuid])
@@ -78,13 +80,13 @@ void main() {
         repository.modifyEvent(modifiedEvent);
 
         when(mockGateway.addEvent(any))
-            .thenAnswer((_) async => Some(eventId));
+            .thenAnswer((_) async => const Right(eventId));
 
         final result = await repository.save();
 
-        expect(result.isSome(), true);
+        expect(result.isRight(), true);
         result.match(
-          () => fail('Expected Some but got None'),
+          (error) => fail('Expected Right but got Left: $error'),
           (id) => expect(id, eventId),
         );
         verify(mockGateway.addEvent(any)).called(1);
@@ -114,7 +116,7 @@ void main() {
         repository.modifyEvent(modifiedEvent);
 
         when(mockGateway.addEvent(any))
-            .thenAnswer((_) async => Some(eventId));
+            .thenAnswer((_) async => const Right(eventId));
 
         await repository.save();
 
@@ -126,21 +128,21 @@ void main() {
         repository.modifyEvent(updatedEvent);
 
         when(mockGateway.updateEvent(eventId, any))
-            .thenAnswer((_) async => true);
+            .thenAnswer((_) async => const Right(unit));
 
         final result = await repository.save();
 
-        expect(result.isSome(), true);
+        expect(result.isRight(), true);
         result.match(
-          () => fail('Expected Some but got None'),
+          (error) => fail('Expected Right but got Left: $error'),
           (id) => expect(id, eventId),
         );
         verify(mockGateway.updateEvent(eventId, any)).called(1);
       });
 
-      test('should return None when no event modified', () async {
+      test('should return Left when no event modified', () async {
         final result = await repository.save();
-        expect(result.isNone(), true);
+        expect(result, const Left<String, String>('Nothing to save.'));
       });
     });
 
@@ -168,7 +170,7 @@ void main() {
         ));
 
         when(mockGateway.addEvent(any))
-            .thenAnswer((_) async => Some(eventId));
+            .thenAnswer((_) async => const Right(eventId));
 
         await repository.save();
 
@@ -203,7 +205,7 @@ void main() {
         ));
 
         when(mockGateway.addEvent(any))
-            .thenAnswer((_) async => Some(eventId));
+            .thenAnswer((_) async => const Right(eventId));
 
         await repository.save();
 


### PR DESCRIPTION
## Summary
- Blank Description/Location silently failed to save on event creation with no useful feedback — the gateway discarded the actual server error and the cubit always showed a hardcoded generic message. `EventsGateway`/`EventsRepository` now return `Either<String, T>` (matching the pattern already used by `AuthGateway`) and surface the real error; the cubit also validates Description/Location client-side before submitting.
- Adds a notifications bell (with unread-count badge) next to Create on the events dashboard, opening a full-screen panel backed by the backend's new `/notifications` endpoints. Rows are collapsed by default and expand in place on tap to show event name, date/time, and location.
- Unread notifications render darker than read ones. The panel always shows every currently-unread notification plus enough already-read ones to keep at least 10 visible total.
- New `NotificationsGateway`/`Repository`/`Cubit` stack mirrors the existing `Events` one. No separate Telegram Mini App work needed since it's the same Flutter web build.

Closes #150