### PR TITLE
ci(mobile): make flutter analyze blocking

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,12 +38,11 @@ jobs:
 
       # The repo ships unit tests under test/ that CI never executed, so a broken
       # test could reach main unnoticed. Run them before the build.
-      # Report-only for now: the tree has ~36 pre-existing analyzer warnings
-      # (lints removed in Dart 3.x still listed in analysis_options.yaml, unused
-      # imports). Blocking on them would block every PR until that cleanup lands.
-      # There are 0 errors, so tighten this to fatal once the warnings are fixed.
-      - name: Analyze (report-only)
-        run: flutter analyze --no-fatal-infos --no-fatal-warnings || true
+      # Errors and warnings now fail the build; the 36 pre-existing warnings were
+      # cleared. Infos stay non-fatal — the tree still has ~141 style-lint infos
+      # (mostly always_put_control_body_on_new_line) that are a separate cleanup.
+      - name: Analyze
+        run: flutter analyze --no-fatal-infos
 
       - name: Run tests
         run: flutter test --reporter compact

--- a/test/unit/blocs/registration_cubit_test.dart
+++ b/test/unit/blocs/registration_cubit_test.dart
@@ -85,10 +85,10 @@ void main() {
 
       final request = _rightRequest(cubit.verificationRequest(false));
 
-      expect(request?.firstName, 'Ada');
-      expect(request?.lastName, 'Lovelace');
-      expect(request?.email, 'ada@innopolis.university');
-      expect(request?.telegram, isNull);
+      expect(request.firstName, 'Ada');
+      expect(request.lastName, 'Lovelace');
+      expect(request.email, 'ada@innopolis.university');
+      expect(request.telegram, isNull);
     });
 
     test('returns clear message for too-short Telegram alias', () {


### PR DESCRIPTION
Completes the analyzer thread. After the previous cleanup (36 → 4 warnings), the last 4 were unnecessary null-aware operators in `registration_cubit_test.dart` — `_rightRequest` returns a non-nullable `RegisterRequest`, so `?.` was redundant.

With warnings at zero, this drops `--no-fatal-warnings` **and the `|| true`**. The `|| true` was worth removing on its own: it swallowed everything, so even a genuine analyzer *error* could not fail CI.

Infos stay non-fatal — ~141 style-lint infos remain (mostly `always_put_control_body_on_new_line`), which is a separate cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)