### PR TITLE
ci(mobile): measure test coverage

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -45,7 +45,35 @@ jobs:
         run: flutter analyze --no-fatal-infos
 
       - name: Run tests
-        run: flutter test --reporter compact
+        run: flutter test --coverage --reporter compact
+
+      # Reports only — there is no signal today about which parts of lib/ the
+      # 15 test files actually reach. Parsed straight from lcov.info so no extra
+      # tooling is needed. Add a threshold once the baseline is known.
+      - name: Coverage summary
+        if: always()
+        run: |
+          if [ ! -f coverage/lcov.info ]; then
+            echo "No coverage/lcov.info produced"
+            exit 0
+          fi
+          awk -F: '
+            /^LF:/ { found += $2 }
+            /^LH:/ { hit   += $2 }
+            END {
+              if (found > 0)
+                printf("TOTAL line coverage: %.1f%% (%d/%d lines)\n", hit * 100 / found, hit, found)
+              else
+                print "no coverage data"
+            }
+          ' coverage/lcov.info
+          echo "── least-covered files ──"
+          awk '
+            /^SF:/          { file = substr($0, 4); lf = 0; lh = 0 }
+            /^LF:/          { lf = substr($0, 4) }
+            /^LH:/          { lh = substr($0, 4) }
+            /^end_of_record/ { if (lf > 0) printf("%6.1f%%  %5d lines  %s\n", lh * 100 / lf, lf, file) }
+          ' coverage/lcov.info | sort -n | head -20
 
       - name: Build Flutter web
         run: |


### PR DESCRIPTION
Mobile runs 15 test files against **182 lib files**, but nothing reports which parts they actually reach — the same blind spot the backend had before #152.

Adds `--coverage` to the test run and a summary step that prints the total plus the 20 least-covered files, parsed directly from `lcov.info` with awk so no extra tooling or third-party action is needed.

Reporting only for now. Once CI shows the baseline I'll follow up with a threshold and tests for the weakest areas, the same way the backend floor was introduced and then ratcheted 72 → 84.

🤖 Generated with [Claude Code](https://claude.com/claude-code)