### PR TITLE
ci(mobile): add Google Play release pipeline

### DIFF
--- a/.github/workflows/release-android.yml
+++ b/.github/workflows/release-android.yml
@@ -1,0 +1,177 @@
+name: Release Android (Google Play)
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Builds a signed Android App Bundle and uploads it to Google Play.
+#
+# Play requires an .aab — build-apk.sh produces an .apk for RuStore, so this is
+# a separate pipeline rather than a change to that script.
+#
+# Deliberately NOT run on every push to main: publishing to Play is an outward
+# facing action, so it is manual (workflow_dispatch) or tag-driven (v*).
+#
+# Required repository secrets — see docs/google-play-setup.md:
+#   ANDROID_KEYSTORE_BASE64    base64 of the upload keystore (.jks)
+#   ANDROID_KEYSTORE_PASSWORD  keystore password
+#   ANDROID_KEY_ALIAS          key alias inside the keystore (e.g. upload)
+#   ANDROID_KEY_PASSWORD       key password
+#   PLAY_SERVICE_ACCOUNT_JSON  Google Play service-account JSON key
+#   API_BASE_URL / APP_METRICA_KEY / IU_ALUMNI_WEB_SALT  (already exist)
+# ─────────────────────────────────────────────────────────────────────────────
+
+on:
+  workflow_dispatch:
+    inputs:
+      track:
+        description: 'Play track to publish to'
+        required: true
+        type: choice
+        default: internal
+        options: [internal, alpha, beta, production]
+      release_status:
+        description: 'draft = upload only, completed = roll out to the track'
+        required: true
+        type: choice
+        default: draft
+        options: [draft, completed]
+      version_name:
+        description: 'Override version name (defaults to pubspec, e.g. 1.0.0)'
+        required: false
+        type: string
+  push:
+    tags: ['v*']
+
+permissions:
+  contents: read
+
+env:
+  # versionCode must increase on every upload Play accepts. run_number is
+  # monotonic per workflow, and the offset leaves room for builds published
+  # before this pipeline existed.
+  VERSION_CODE_OFFSET: 100
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+          cache: true
+
+      - name: Install dependencies
+        run: flutter pub get
+
+      - name: Generate code (build_runner)
+        run: dart run build_runner build --delete-conflicting-outputs
+
+      - name: Run tests
+        run: flutter test --reporter compact
+
+      - name: Resolve version
+        id: version
+        run: |
+          set -euo pipefail
+          PUBSPEC_VERSION=$(grep -E '^version:' pubspec.yaml | awk '{print $2}' | cut -d+ -f1)
+          NAME="${{ inputs.version_name }}"
+          if [ -z "$NAME" ]; then
+            # A v* tag names the release; otherwise fall back to pubspec.
+            REF="${GITHUB_REF##*/}"
+            case "$GITHUB_REF" in
+              refs/tags/v*) NAME="${REF#v}" ;;
+              *)            NAME="$PUBSPEC_VERSION" ;;
+            esac
+          fi
+          CODE=$(( ${{ env.VERSION_CODE_OFFSET }} + GITHUB_RUN_NUMBER ))
+          echo "name=$NAME"  >> "$GITHUB_OUTPUT"
+          echo "code=$CODE"  >> "$GITHUB_OUTPUT"
+          echo "Building $NAME ($CODE)"
+
+      - name: Decode upload keystore
+        env:
+          KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+        run: |
+          set -euo pipefail
+          if [ -z "${KEYSTORE_BASE64:-}" ]; then
+            echo "::error::ANDROID_KEYSTORE_BASE64 is not set — see docs/google-play-setup.md"
+            exit 1
+          fi
+          printf '%s' "$KEYSTORE_BASE64" | base64 -d > "$RUNNER_TEMP/upload-keystore.jks"
+          echo "keystore written ($(wc -c < "$RUNNER_TEMP/upload-keystore.jks") bytes)"
+
+      - name: Build signed App Bundle
+        env:
+          # android/app/build.gradle already reads these.
+          KEYSTORE_PATH: ${{ runner.temp }}/upload-keystore.jks
+          KEYSTORE_PASS: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+          KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+          KEY_PASS: ${{ secrets.ANDROID_KEY_PASSWORD }}
+        run: |
+          flutter build appbundle --release \
+            --build-name="${{ steps.version.outputs.name }}" \
+            --build-number="${{ steps.version.outputs.code }}" \
+            --dart-define=API_BASE_URL=${{ secrets.API_BASE_URL }} \
+            --dart-define=APP_METRICA_KEY=${{ secrets.APP_METRICA_KEY }} \
+            --dart-define=IU_ALUMNI_WEB_SALT=${{ secrets.IU_ALUMNI_WEB_SALT }}
+
+      - name: Verify the bundle is signed with the upload key
+        run: |
+          set -euo pipefail
+          AAB=build/app/outputs/bundle/release/app-release.aab
+          ls -la "$AAB"
+          # A debug-signed bundle would be rejected by Play with a confusing
+          # error, so fail here where the cause is obvious.
+          if unzip -l "$AAB" | grep -q "META-INF/.*\.RSA\|META-INF/.*\.EC"; then
+            echo "bundle carries a signature block"
+          else
+            echo "::error::App Bundle does not appear to be signed"
+            exit 1
+          fi
+
+      - name: Upload bundle as a build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: app-release-${{ steps.version.outputs.code }}.aab
+          path: build/app/outputs/bundle/release/app-release.aab
+          retention-days: 14
+
+      - name: Publish to Google Play
+        env:
+          PLAY_JSON: ${{ secrets.PLAY_SERVICE_ACCOUNT_JSON }}
+          TRACK: ${{ inputs.track || 'internal' }}
+          STATUS: ${{ inputs.release_status || 'draft' }}
+        run: |
+          set -euo pipefail
+          if [ -z "${PLAY_JSON:-}" ]; then
+            echo "::error::PLAY_SERVICE_ACCOUNT_JSON is not set — see docs/google-play-setup.md"
+            exit 1
+          fi
+          printf '%s' "$PLAY_JSON" > "$RUNNER_TEMP/play.json"
+
+          # fastlane's `supply` talks to the Play Developer API directly. Used as
+          # a CLI rather than a GitHub Action so nothing third-party runs with
+          # access to the workflow token.
+          gem install --no-document fastlane
+          fastlane supply \
+            --package_name com.innopolis.alumni \
+            --aab build/app/outputs/bundle/release/app-release.aab \
+            --track "$TRACK" \
+            --release_status "$STATUS" \
+            --json_key "$RUNNER_TEMP/play.json" \
+            --skip_upload_metadata true \
+            --skip_upload_images true \
+            --skip_upload_screenshots true \
+            --skip_upload_changelogs true
+
+      - name: Clean up credentials
+        if: always()
+        run: rm -f "$RUNNER_TEMP/upload-keystore.jks" "$RUNNER_TEMP/play.json"

--- a/docs/google-play-setup.md
+++ b/docs/google-play-setup.md
@@ -1,0 +1,137 @@
+# Publishing IU Alumni to Google Play
+
+One-time setup for the `Release Android (Google Play)` workflow.
+
+The app is already Android-ready: package `com.innopolis.alumni`, label "IU Alumni",
+and `android/app/build.gradle` reads its signing config from environment
+variables. What was missing was an **App Bundle** build (Play does not accept the
+`.apk` that `build-apk.sh` produces for RuStore) and a way to upload it.
+
+Steps marked **[you]** must be done by a human — they involve account creation,
+payment, or accepting legal agreements.
+
+---
+
+## 1. Google Play developer account **[you]**
+
+<https://play.google.com/console/signup> — one-time **$25** fee, and you must
+accept the Developer Distribution Agreement.
+
+For a university-owned app, register an **organisation** account rather than a
+personal one, so ownership survives people leaving. Organisation accounts need
+a D-U-N-S number and take longer to verify — start this first, it is the long
+pole.
+
+## 2. Create the app **[you]**
+
+Play Console → **Create app**:
+
+| field | value |
+|---|---|
+| App name | IU Alumni |
+| Default language | English (or Russian, if that is the primary audience) |
+| App or game | App |
+| Free or paid | Free |
+
+Then **Dashboard → Set up your app** and complete every item. Play will not let
+you roll out to *any* track, including internal testing, until these are done:
+
+- Privacy policy URL — required because the app handles accounts and email
+- Data safety — declare what is collected. Be accurate: the app sends email,
+  name, graduation year, location, and Telegram alias to your own backend
+- Content rating questionnaire
+- Target audience and content
+- Ads declaration — the app has no ads; the `AD_ID` permission is commented out
+  in `AndroidManifest.xml`, which matches "no advertising ID"
+- App category and contact details
+
+## 3. Generate the upload keystore **[you]**
+
+Do this yourself so the password never passes through anyone else. From the repo:
+
+```bash
+./build-apk.sh --generate-keystore
+```
+
+That writes `~/iu-alumni-release.jks`. Or directly:
+
+```bash
+keytool -genkeypair -v -keystore ~/iu-alumni-release.jks \
+  -keyalg RSA -keysize 2048 -validity 10000 -alias upload
+```
+
+> **Back this file up somewhere durable.** With Play App Signing, Google holds
+> the *app signing* key and this is your *upload* key — a lost upload key can be
+> reset by Google support, but it is a slow process. Losing it is recoverable;
+> losing it *and* having no account access is not.
+
+## 4. Google Play service account **[you]**
+
+This is what lets CI upload without a human.
+
+1. Play Console → **Setup → API access** → link (or create) a Google Cloud project
+2. In Google Cloud → **IAM & Admin → Service Accounts** → create one, e.g.
+   `play-publisher`
+3. On that service account → **Keys → Add key → JSON** → download it
+4. Back in Play Console → **Users and permissions → Invite new user** → paste the
+   service-account email, and grant **app-level** access to IU Alumni with:
+   - *Release to testing tracks*
+   - *Release to production* (only if you want CI to publish live)
+
+Least privilege: grant only the testing-track permission until you trust the
+pipeline end to end.
+
+## 5. Add repository secrets **[you]**
+
+`Settings → Secrets and variables → Actions` in `iu-alumni-mobile`. The workflow
+uses the **production** environment, so add them there (or at repo level).
+
+| secret | value |
+|---|---|
+| `ANDROID_KEYSTORE_BASE64` | `base64 -i ~/iu-alumni-release.jks` (macOS) / `base64 -w0` (Linux) |
+| `ANDROID_KEYSTORE_PASSWORD` | keystore password from step 3 |
+| `ANDROID_KEY_ALIAS` | `upload` |
+| `ANDROID_KEY_PASSWORD` | key password (often the same) |
+| `PLAY_SERVICE_ACCOUNT_JSON` | full contents of the JSON from step 4 |
+
+`API_BASE_URL`, `APP_METRICA_KEY` and `IU_ALUMNI_WEB_SALT` already exist.
+
+## 6. First upload
+
+Play sometimes rejects the very first API upload for an app that has never had a
+bundle. If step 7 fails with *"Package not found"* or similar, upload the
+artifact once by hand — run the workflow, download the `app-release-*.aab`
+artifact it attaches, and drop it into **Internal testing → Create new release**.
+Subsequent runs go through the API fine.
+
+## 7. Run the pipeline
+
+Actions → **Release Android (Google Play)** → Run workflow:
+
+- `track`: `internal` to start
+- `release_status`: `draft` — uploads without rolling out, so you can inspect it
+  in the console first
+
+Once you trust it, use `completed` to roll out, and `beta` / `production` as the
+app matures. Pushing a `v*` tag also triggers a build.
+
+### Versioning
+
+`versionCode` is `100 + github.run_number`, so it always increases — Play rejects
+a bundle whose code is not higher than the last one. `versionName` comes from a
+`v*` tag if present, otherwise `pubspec.yaml`, and can be overridden per run.
+
+The offset exists so codes stay above anything published before this pipeline. If
+you have already shipped a build with a code above 100, raise
+`VERSION_CODE_OFFSET` in the workflow.
+
+---
+
+## What is not automated
+
+- **Store listing** (description, screenshots, feature graphic) — the upload runs
+  with `--skip_upload_metadata` and friends, so CI never overwrites what you
+  write in the console. Add a `fastlane/metadata` tree later if you want it in git.
+- **Staged rollouts** — add `--rollout 0.1` to the `fastlane supply` call.
+- **iOS / App Store** — separate pipeline, needs an Apple Developer account
+  ($99/year) and a macOS runner.


### PR DESCRIPTION
Mobile CI only ever built Flutter **web** — no Android artifact was produced at all. `build-apk.sh` builds an `.apk` for RuStore, which Play doesn't accept, so this adds a separate pipeline that builds a signed **App Bundle** and publishes it.

## Pipeline

- **Manual or tag-driven only** (`workflow_dispatch` / `v*`). Publishing is outward-facing, so it deliberately does not fire on every push to main.
- Defaults to **`internal` track, `draft` status** — the first runs upload without rolling anything out, so you can inspect the release in the console first.
- Runs `flutter test` before building.
- `versionCode` = `100 + run_number`, so it always increases (Play rejects a non-increasing code). `versionName` comes from the tag, an input, or `pubspec.yaml`.
- The `.aab` is attached as a build artifact — useful because Play sometimes refuses the very first *API* upload for an app that has never had a bundle; you can drag that artifact into the console once and subsequent runs work.
- Signing reuses the `KEYSTORE_PATH` / `KEYSTORE_PASS` / `KEY_ALIAS` / `KEY_PASS` env vars that `android/app/build.gradle` already reads — no gradle changes needed.
- Upload uses **`fastlane supply` as a CLI**, not a third-party GitHub Action, so nothing external runs with access to the workflow token. Keystore and service-account JSON are deleted in an `always()` step.

## Before it can run

Five new secrets are needed (`ANDROID_KEYSTORE_BASE64`, `ANDROID_KEYSTORE_PASSWORD`, `ANDROID_KEY_ALIAS`, `ANDROID_KEY_PASSWORD`, `PLAY_SERVICE_ACCOUNT_JSON`). `API_BASE_URL`, `APP_METRICA_KEY` and `IU_ALUMNI_WEB_SALT` already exist.

`docs/google-play-setup.md` walks through the parts that need a human: developer account, app creation and content declarations, keystore generation, and the Play service account.

🤖 Generated with [Claude Code](https://claude.com/claude-code)