### PR TITLE
ci: pass DOMAIN and ENVIRONMENT to the smoke test

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -141,6 +141,8 @@ jobs:
       SERVER_HOST: ${{ secrets.SERVER_HOST }}
       SERVER_USER: ${{ secrets.SERVER_USER }}
       SERVER_SSH_KEY: ${{ secrets.SERVER_SSH_KEY }}
+      DOMAIN: ${{ secrets.DOMAIN }}
+      ENVIRONMENT: ${{ secrets.ENVIRONMENT }}
 
   smoke-production:
     needs: deploy-production
@@ -151,3 +153,5 @@ jobs:
       SERVER_HOST: ${{ secrets.SERVER_HOST }}
       SERVER_USER: ${{ secrets.SERVER_USER }}
       SERVER_SSH_KEY: ${{ secrets.SERVER_SSH_KEY }}
+      DOMAIN: ${{ secrets.DOMAIN }}
+      ENVIRONMENT: ${{ secrets.ENVIRONMENT }}


### PR DESCRIPTION
Smoke has failed on every run here since iu-alumni-infra#82 moved the HTTP checks to the public hostnames: `FAIL: DOMAIN secret is empty`.

`smoke-test.yml` is a reusable workflow, so it only receives secrets the caller passes explicitly — `DOMAIN`/`ENVIRONMENT` were not among them, and until now didn't exist in this repo at all.

iu-alumni-infra#84 provisions both secrets here via Terraform and declares them as optional inputs. This passes them through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)