### PR TITLE
fix(events): add fallback for failed cover requests

### DIFF
--- a/lib/application/repositories/events/events_repository_impl.dart
+++ b/lib/application/repositories/events/events_repository_impl.dart
@@ -23,7 +23,15 @@ class EventsRepositoryImpl implements EventsRepository {
   Set<String>? _owned;
   Set<String>? _participated;
   EventModel? _modifiedEvent;
-  final Map<String, String?> _coverCache = {};
+  final Map<String, String> _coverCache = {};
+
+  void _cacheCover(String eventId, String? cover) {
+    if (cover == null || cover.isEmpty) {
+      _coverCache.remove(eventId);
+    } else {
+      _coverCache[eventId] = cover;
+    }
+  }
 
   @override
   Future<Iterable<EventModel>> getEvents() async {
@@ -123,7 +131,7 @@ class EventsRepositoryImpl implements EventsRepository {
       return result.match(Left.new, (_) {
         // Update the event in the cache on success
         _cache![event.eventId] = event;
-        _coverCache[event.eventId] = event.coverBytes;
+        _cacheCover(event.eventId, event.coverBytes);
         // When modified, the event ID stays the same
         return Right(event.eventId);
       });
@@ -140,7 +148,7 @@ class EventsRepositoryImpl implements EventsRepository {
             if (myProfile case Some(:final value)) value.profileId,
           ].toISet(),
         );
-        _coverCache[eid] = event.coverBytes;
+        _cacheCover(eid, event.coverBytes);
         _owned!.add(eid);
         return Right(eid);
       });
@@ -177,11 +185,14 @@ class EventsRepositoryImpl implements EventsRepository {
     if (cachedEventCover != null) {
       return cachedEventCover;
     }
-    if (_coverCache.containsKey(eventId)) {
-      return _coverCache[eventId];
+    final cachedCover = _coverCache[eventId];
+    if (cachedCover != null) {
+      return cachedCover;
     }
     final cover = await _gateway.loadCover(eventId);
-    _coverCache[eventId] = cover;
+    // A failed request returns null. Do not permanently cache that failure,
+    // so a later rebuild or navigation can recover without restarting the app.
+    _cacheCover(eventId, cover);
     return cover;
   }
 
@@ -194,7 +205,7 @@ class EventsRepositoryImpl implements EventsRepository {
     if (!success && deletedModel != null) {
       // Return the deleted event back if it wasn't deleted
       _cache?[eventId] = deletedModel;
-      _coverCache[eventId] = deletedCover;
+      _cacheCover(eventId, deletedCover);
       _owned?.remove(eventId);
     }
   }

--- a/lib/data/events/events_gateway_impl.dart
+++ b/lib/data/events/events_gateway_impl.dart
@@ -8,6 +8,7 @@ import '../common/dio_options_manager.dart';
 import '../models/event_data_model.dart';
 import '../models/event_request_data_model.dart';
 import '../paths.dart';
+import '../../util/logger.dart';
 import 'events_gateway.dart';
 
 class EventsGatewayImpl implements EventsGateway {
@@ -88,8 +89,22 @@ class EventsGatewayImpl implements EventsGateway {
       );
       final data = response.data;
       return data is Map<String, dynamic> ? data['cover'] as String? : null;
-    } catch (_) {
-      return null;
+    } catch (error) {
+      logger.w('Dedicated cover request failed for $eventId: $error');
+      // Compatibility fallback for deployments where the dedicated image
+      // route is temporarily unavailable. The full event response contains
+      // the same cover field.
+      try {
+        final response = await _dio.get(
+          Paths.eventWithId(eventId),
+          options: _optionsManager.opts(),
+        );
+        final data = response.data;
+        return data is Map<String, dynamic> ? data['cover'] as String? : null;
+      } catch (fallbackError) {
+        logger.w('Cover fallback failed for $eventId: $fallbackError');
+        return null;
+      }
     }
   }
 

--- a/test/unit/data/events/events_gateway_impl_test.dart
+++ b/test/unit/data/events/events_gateway_impl_test.dart
@@ -1,0 +1,69 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fpdart/fpdart.dart';
+import 'package:ui_alumni_mobile/data/common/dio_options_manager.dart';
+import 'package:ui_alumni_mobile/data/events/events_gateway_impl.dart';
+import 'package:ui_alumni_mobile/data/token/token_provider.dart';
+
+class _TokenProvider extends TokenProvider {
+  @override
+  void clear() {}
+
+  @override
+  Future<void> init() async {}
+
+  @override
+  Option<String> get token => const Some('test-token');
+}
+
+class _CoverFallbackAdapter implements HttpClientAdapter {
+  final requestedPaths = <String>[];
+
+  @override
+  void close({bool force = false}) {}
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<Uint8List>? requestStream,
+    Future<void>? cancelFuture,
+  ) async {
+    requestedPaths.add(options.uri.path);
+    if (options.uri.path.endsWith('/cover')) {
+      return ResponseBody.fromString(
+        jsonEncode({'detail': 'temporary cover route failure'}),
+        503,
+        headers: {
+          Headers.contentTypeHeader: [Headers.jsonContentType],
+        },
+      );
+    }
+    return ResponseBody.fromString(
+      jsonEncode({'cover': 'base64-cover'}),
+      200,
+      headers: {
+        Headers.contentTypeHeader: [Headers.jsonContentType],
+      },
+    );
+  }
+}
+
+void main() {
+  test('falls back to the full event when the cover endpoint fails', () async {
+    final adapter = _CoverFallbackAdapter();
+    final dio = Dio(BaseOptions(baseUrl: 'https://api.example.test'))
+      ..httpClientAdapter = adapter;
+    final gateway = EventsGatewayImpl(dio, DioOptionsManager(_TokenProvider()));
+
+    final cover = await gateway.loadCover('event-1');
+
+    expect(cover, 'base64-cover');
+    expect(adapter.requestedPaths, [
+      '/api/v1/events/event-1/cover',
+      '/api/v1/events/event-1',
+    ]);
+  });
+}

--- a/test/unit/repositories/events/events_repository_impl_test.dart
+++ b/test/unit/repositories/events/events_repository_impl_test.dart
@@ -215,6 +215,7 @@ void main() {
         await repository.deleteEvent(eventId);
 
         // Event should still be in cache
+        when(mockGateway.loadCover(eventId)).thenAnswer((_) async => null);
         final cached = await repository.getOneEvent(eventId);
         expect(cached.isSome(), true);
         cached.match(


### PR DESCRIPTION
## Summary
- Fall back to the full event endpoint when the dedicated cover request fails
- Avoid caching failed cover requests so later attempts can recover
- Add logging for cover-loading failures

## Testing
- 16 focused Flutter tests passed
- Verified locally by blocking `/cover` requests; covers loaded successfully through `/events/{event-id}`