### PR TITLE
Stabilize event cards while covers load and add placeholders

### DIFF
--- a/lib/presentation/common/widgets/event_card.dart
+++ b/lib/presentation/common/widgets/event_card.dart
@@ -75,14 +75,25 @@ class _EventCardState extends State<EventCard> {
               future: _cover,
               builder: (context, snapshot) {
                 final bytes = snapshot.data;
-                if (bytes == null || bytes.isEmpty) {
-                  return const SizedBox.shrink();
-                }
                 return ClipRRect(
                   borderRadius: BorderRadius.circular(16),
                   child: AspectRatio(
                     aspectRatio: 1,
-                    child: Image.memory(base64Decode(bytes), fit: BoxFit.cover),
+                    child: bytes == null || bytes.isEmpty
+                        ? const ColoredBox(
+                            color: Colors.white38,
+                            child: Center(
+                              child: Icon(
+                                Icons.image_outlined,
+                                color: Colors.black26,
+                              ),
+                            ),
+                          )
+                        : Image.memory(
+                            base64Decode(bytes),
+                            fit: BoxFit.cover,
+                            gaplessPlayback: true,
+                          ),
                   ),
                 );
               },

--- a/lib/presentation/pages/events_list/widgets/events_list.dart
+++ b/lib/presentation/pages/events_list/widgets/events_list.dart
@@ -36,6 +36,7 @@ class _EventsListState extends State<EventsList> {
 
   @override
   Widget build(BuildContext context) {
+    final events = widget.events.toList(growable: false);
     final child = MasonryGridView.count(
       crossAxisCount: 2,
       mainAxisSpacing: 8,
@@ -45,9 +46,12 @@ class _EventsListState extends State<EventsList> {
         horizontal: 8,
         vertical: 16,
       ).copyWith(bottom: RootPage.navigationBarHeight + 16),
-      itemCount: widget.events.length,
-      itemBuilder: (context, i) =>
-          EventCard(color: _colorFor(i), event: widget.events.elementAt(i)),
+      itemCount: events.length,
+      itemBuilder: (context, i) => EventCard(
+        key: ValueKey(events[i].eventId),
+        color: _colorFor(i),
+        event: events[i],
+      ),
     );
     return widget.refresh != null
         ? SmartRefresher(


### PR DESCRIPTION
## Summary

- Adds fixed-size placeholders while event covers load.
- Prevents masonry cards from changing position when covers appear.
- Adds stable event keys and avoids repeated event-list traversal.
- Keeps failed or missing covers as placeholders.

Closes #172 

## Testing

- Verified changed files introduce no new analyzer issues.
- Manually test with cover requests throttled or blocked.